### PR TITLE
tests and bugfix for line-after-title

### DIFF
--- a/lib/rules/line-after-title.js
+++ b/lib/rules/line-after-title.js
@@ -12,7 +12,7 @@ module.exports = {
 , options: {}
 , validate: (context, rule) => {
     // all commits should have a body and a blank line after the title
-    if (!context.body.length || context.body[0]) {
+    if (context.body[0]) {
       context.report({
         id: id
       , message: 'blank line expected after title'

--- a/test/rules/line-after-title.js
+++ b/test/rules/line-after-title.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const test = require('tap').test
+const Rule = require('../../lib/rules/line-after-title')
+const Commit = require('gitlint-parser-node')
+const Validator = require('../../')
+
+test('rule: line-after-title', (t) => {
+  t.test('no blank line', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea'
+    , author: {
+        name: 'Evan Lucas'
+      , email: 'evanlucas@me.com'
+      , date: '2016-04-12T19:42:23Z'
+      }
+    , message: 'test: fix something\nfhqwhgads'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'line-after-title', 'id')
+      tt.equal(opts.message, 'blank line expected after title', 'message')
+      tt.equal(opts.string, 'fhqwhgads', 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  }),
+
+  t.test('blank line', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea'
+    , author: {
+        name: 'Evan Lucas'
+      , email: 'evanlucas@me.com'
+      , date: '2016-04-12T19:42:23Z'
+      }
+    , message: 'test: fix something\n\nfhqwhgads'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'line-after-title', 'id')
+      tt.equal(opts.message, 'blank line after title', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.end()
+})

--- a/test/rules/line-after-title.js
+++ b/test/rules/line-after-title.js
@@ -30,7 +30,7 @@ test('rule: line-after-title', (t) => {
     }
 
     Rule.validate(context)
-  }),
+  })
 
   t.test('blank line', (tt) => {
     tt.plan(4)
@@ -43,6 +43,29 @@ test('rule: line-after-title', (t) => {
       , date: '2016-04-12T19:42:23Z'
       }
     , message: 'test: fix something\n\nfhqwhgads'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'line-after-title', 'id')
+      tt.equal(opts.message, 'blank line after title', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('just one line', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea'
+    , author: {
+        name: 'Evan Lucas'
+      , email: 'evanlucas@me.com'
+      , date: '2016-04-12T19:42:23Z'
+      }
+    , message: 'test: fix something'
     }, v)
 
     context.report = (opts) => {


### PR DESCRIPTION
Add tests for line-after-title.

Change line-after-title so that it does not report an error for commit messages that are a title line only.