### PR TITLE
Allow colons in commit message title

### DIFF
--- a/lib/rules/title-format.js
+++ b/lib/rules/title-format.js
@@ -23,7 +23,7 @@ module.exports = {
     }
 
     {
-      const result = /^(.+?:)[^ ]/.exec(context.title)
+      const result = /^([^:]+:)[^ ]/.exec(context.title)
       if (result) {
         context.report({
           id: id

--- a/test/rules/title-format.js
+++ b/test/rules/title-format.js
@@ -39,6 +39,24 @@ test('rule: title-format', (t) => {
     tt.end()
   })
 
+  t.test('space after subsystem, colon in message', (tt) => {
+    tt.plan(2)
+    const context = makeCommit('test: missing:space')
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.strictSame(opts, {
+        id: 'title-format'
+      , message: 'Title is formatted correctly.'
+      , string: ''
+      , level: 'pass'
+      })
+    }
+
+    Rule.validate(context)
+    tt.end()
+  })
+
   t.test('consecutive spaces', (tt) => {
     tt.plan(2)
     const context = makeCommit('test: with  two spaces')


### PR DESCRIPTION
The title-format rule was previously too eager and disallowed
all usage of colons followed by non-spaces, rather than just
for the subsystem. Fix that by only checking for a space after
the *first* colon.

Fixes: https://github.com/nodejs/core-validate-commit/issues/40