### PR TITLE
rules: only check case of first word after subsystem

### DIFF
--- a/lib/rules/title-format.js
+++ b/lib/rules/title-format.js
@@ -52,7 +52,7 @@ module.exports = {
       }
     }
 
-    const result = /^(.+?): [A-Z]/.exec(context.title)
+    const result = /^([^:]+?): [A-Z]/.exec(context.title)
     if (result) {
       context.report({
         id: id

--- a/test/rules/title-format.js
+++ b/test/rules/title-format.js
@@ -77,5 +77,43 @@ test('rule: title-format', (t) => {
     tt.end()
   })
 
+  t.test('first word after subsystem should be in lowercase', (tt) => {
+    tt.plan(2)
+    const context = makeCommit('test: Some message')
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.strictSame(opts, {
+        id: 'title-format'
+      , message: 'First word after subsystem(s) in title should be lowercase.'
+      , string: 'test: Some message'
+      , line: 0
+      , column: 7
+      , level: 'fail'
+      })
+    }
+
+    Rule.validate(context)
+    tt.end()
+  })
+
+  t.test('colon in message followed by uppercase word', (tt) => {
+    tt.plan(2)
+    const context = makeCommit('test: some message: Message')
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.strictSame(opts, {
+        id: 'title-format'
+      , message: 'Title is formatted correctly.'
+      , string: ''
+      , level: 'pass'
+      })
+    }
+
+    Rule.validate(context)
+    tt.end()
+  })
+
   t.end()
 })


### PR DESCRIPTION
The first colon denotes the subsystem(s). Any further colons are part
of the title and should not be subject to the rule that the following
word be in lowercase.

Refs: https://github.com/nodejs/node/pull/26308#issuecomment-467670622