### PR TITLE
doc: update README.md badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # core-validate-commit
 
-[![Build Status](https://travis-ci.org/nodejs/core-validate-commit.svg)](https://travis-ci.org/nodejs/core-validate-commit)
-[![Coverage Status](https://coveralls.io/repos/evanlucas/core-validate-commit/badge.svg?branch=master&service=github)](https://coveralls.io/github/evanlucas/core-validate-commit?branch=master)
+[![Build Status](https://travis-ci.com/nodejs/core-validate-commit.svg?branch=master)](https://travis-ci.com/nodejs/core-validate-commit)
 
 Validate the commit message for a particular commit in node core
 


### PR DESCRIPTION
Update Travis CI badge to correct URL. Remove Coveralls, which hasn't
worked since this module was moved into the Node.js organization.