### PR TITLE
test: add tests for release commits

### DIFF
--- a/test/rules/reviewers.js
+++ b/test/rules/reviewers.js
@@ -35,5 +35,33 @@ This is a test`
     Rule.validate(context)
   })
 
+  t.test('skip for release commit', (tt) => {
+    tt.plan(2)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea'
+    , author: {
+        name: 'Evan Lucas'
+      , email: 'evanlucas@me.com'
+      , date: '2016-04-12T19:42:23Z'
+      }
+    , message: `2016-04-12, Version x.y.z
+
+This is a test`
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.strictSame(opts, {
+        id: 'reviewers'
+      , message: 'skipping reviewers for release commit'
+      , string: ''
+      , level: 'skip'
+      })
+    }
+
+    Rule.validate(context)
+  })
+
   t.end()
 })

--- a/test/rules/subsystem.js
+++ b/test/rules/subsystem.js
@@ -33,6 +33,34 @@ test('rule: subsystem', (t) => {
     Rule.validate(context, {options: {subsystems: Rule.defaults.subsystems}})
   })
 
+  t.test('skip for release commit', (tt) => {
+    tt.plan(2)
+
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea'
+    , author: {
+        name: 'Evan Lucas'
+      , email: 'evanlucas@me.com'
+      , date: '2016-04-12T19:42:23Z'
+      }
+    , message: '2016-04-12, Version x.y.z'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.strictSame(opts, {
+        id: 'subsystem'
+      , message: 'Release commits do not have subsystems'
+      , string: ''
+      , level: 'skip'
+      })
+      tt.end()
+    }
+
+    Rule.validate(context, {options: {subsystems: Rule.defaults.subsystems}})
+  })
+
   t.test('valid', (tt) => {
     tt.plan(2)
 
@@ -60,6 +88,5 @@ test('rule: subsystem', (t) => {
 
     Rule.validate(context, {options: {subsystems: Rule.defaults.subsystems}})
   })
-
   t.end()
 })


### PR DESCRIPTION
Covers uncovered lines in `reviewers.js` and `subsystems.js` reported in the coverage report.

Before
```console
--------------------------------|----------|----------|----------|----------|-------------------|
File                            |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------------------|----------|----------|----------|----------|-------------------|
All files                       |    95.57 |     88.3 |      100 |    95.92 |                   |
 core-validate-commit           |      100 |      100 |      100 |      100 |                   |
  index.js                      |      100 |      100 |      100 |      100 |                   |
 core-validate-commit/lib       |    94.55 |       80 |      100 |    94.44 |                   |
  index.js                      |    97.62 |     87.5 |      100 |    97.56 |                68 |
  rule.js                       |    84.62 |       50 |      100 |    84.62 |             12,16 |
 core-validate-commit/lib/rules |    95.92 |    90.54 |      100 |    96.45 |                   |
  fixes-url.js                  |       95 |       90 |      100 |    94.74 |                66 |
  index.js                      |       90 |       75 |      100 |      100 |                 8 |
  line-after-title.js           |      100 |       75 |      100 |      100 |                19 |
  line-length.js                |      100 |      100 |      100 |      100 |                   |
  metadata-end.js               |      100 |    83.33 |      100 |      100 |                17 |
  pr-url.js                     |    94.12 |       90 |      100 |    93.75 |                48 |
  reviewers.js                  |    77.78 |    83.33 |      100 |    77.78 |             17,23 |
  subsystem.js                  |    94.12 |       90 |      100 |    94.12 |               101 |
  title-format.js               |      100 |      100 |      100 |      100 |                   |
  title-length.js               |      100 |      100 |      100 |      100 |                   |
--------------------------------|----------|----------|----------|----------|-------------------|
```

After
```console
--------------------------------|----------|----------|----------|----------|-------------------|
File                            |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------------------|----------|----------|----------|----------|-------------------|
All files                       |    97.04 |    90.43 |      100 |    97.45 |                   |
 core-validate-commit           |      100 |      100 |      100 |      100 |                   |
  index.js                      |      100 |      100 |      100 |      100 |                   |
 core-validate-commit/lib       |    94.55 |       80 |      100 |    94.44 |                   |
  index.js                      |    97.62 |     87.5 |      100 |    97.56 |                68 |
  rule.js                       |    84.62 |       50 |      100 |    84.62 |             12,16 |
 core-validate-commit/lib/rules |    97.96 |    93.24 |      100 |    98.58 |                   |
  fixes-url.js                  |       95 |       90 |      100 |    94.74 |                66 |
  index.js                      |       90 |       75 |      100 |      100 |                 8 |
  line-after-title.js           |      100 |       75 |      100 |      100 |                19 |
  line-length.js                |      100 |      100 |      100 |      100 |                   |
  metadata-end.js               |      100 |    83.33 |      100 |      100 |                17 |
  pr-url.js                     |    94.12 |       90 |      100 |    93.75 |                48 |
  reviewers.js                  |      100 |      100 |      100 |      100 |                   |
  subsystem.js                  |      100 |      100 |      100 |      100 |                   |
  title-format.js               |      100 |      100 |      100 |      100 |                   |
  title-length.js               |      100 |      100 |      100 |      100 |                   |
--------------------------------|----------|----------|----------|----------|-------------------|
```