### PR TITLE
Stricter URL checks

### DIFF
--- a/lib/rules/fixes-url.js
+++ b/lib/rules/fixes-url.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const id = 'fixes-url'
+const github = new RegExp('^https://github\.com/\\w+\/\\w+/' +
+  '(issues|pull)/\\d+(#issuecomment-\\d+|#discussion_r\\d+)?$'
+)
 
 module.exports = {
   id: id
@@ -21,28 +24,53 @@ module.exports = {
       })
       return
     }
+    // Allow GitHub issues with optional comment.
+    // GitHub pull requests must reference a comment or discussion.
     for (const url of parsed.fixes) {
+      const match = github.exec(url)
       if (url[0] === '#') {
         // See nodejs/node#2aa376914b621018c5784104b82c13e78ee51307
         // for an example
         const { line, column } = findLineAndColumn(context.body, url)
         context.report({
           id: id
-        , message: 'Fixes must be a url, not an issue number.'
+        , message: 'Fixes must be a URL, not an issue number.'
         , string: url
         , line: line
         , column: column
         , level: 'fail'
         })
+      } else if (match) {
+        if (match[1] === 'pull' && match[2] === undefined) {
+          const { line, column } = findLineAndColumn(context.body, url)
+          context.report({
+            id: id
+          , message: 'Pull request URL must reference a comment or discussion.'
+          , string: url
+          , line: line
+          , column: column
+          , level: 'fail'
+          })
+        } else {
+          const { line, column } = findLineAndColumn(context.body, url)
+          context.report({
+            id: id
+          , message: 'Valid fixes URL.'
+          , string: url
+          , line: line
+          , column: column
+          , level: 'pass'
+          })
+        }
       } else {
         const { line, column } = findLineAndColumn(context.body, url)
         context.report({
           id: id
-        , message: 'Valid fixes url'
+        , message: 'Fixes must be a GitHub URL.'
         , string: url
         , line: line
         , column: column
-        , level: 'pass'
+        , level: 'fail'
         })
       }
     }

--- a/lib/rules/pr-url.js
+++ b/lib/rules/pr-url.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const id = 'pr-url'
+const prUrl = /^https:\/\/github\.com\/\w+\/\w+\/pull\/\d+$/
 
 module.exports = {
   id: id
@@ -22,33 +23,42 @@ module.exports = {
       })
       return
     }
-    if (context.prUrl) {
-      if (context.prUrl[0] === '#') {
-        // see nodejs/node#7d3a7ea0d7df9b6f11df723dec370f49f4f87e99
-        // for an example
-        var line = -1
-        var column = -1
-        for (var i = 0; i < context.body.length; i++) {
-          const l = context.body[i]
-          if (~l.indexOf('PR-URL') && ~l.indexOf(context.prUrl)) {
-            line = i
-            column = l.indexOf(context.prUrl)
-          }
-        }
-        context.report({
-          id: id
-        , message: 'PR-URL must be a url, not a pr number.'
-        , string: context.prUrl
-        , line: line
-        , column: column
-        , level: 'fail'
-        })
+    var line = -1
+    var column = -1
+    for (var i = 0; i < context.body.length; i++) {
+      const l = context.body[i]
+      if (~l.indexOf('PR-URL') && ~l.indexOf(context.prUrl)) {
+        line = i
+        column = l.indexOf(context.prUrl)
       }
+    }
+    if (context.prUrl[0] === '#') {
+      // see nodejs/node#7d3a7ea0d7df9b6f11df723dec370f49f4f87e99
+      // for an example
+      context.report({
+        id: id
+      , message: 'PR-URL must be a URL, not a pull request number.'
+      , string: context.prUrl
+      , line: line
+      , column: column
+      , level: 'fail'
+      })
+    } else if (!prUrl.test(context.prUrl)) {
+      context.report({
+        id: id
+      , message: 'PR-URL must be a GitHub pull request URL.'
+      , string: context.prUrl
+      , line: line
+      , column: column
+      , level: 'fail'
+      })
     } else {
       context.report({
         id: id
-      , message: 'PR-URL is valid'
+      , message: 'PR-URL is valid.'
       , string: context.prUrl
+      , line: line
+      , column: column
       , level: 'pass'
       })
     }

--- a/test/rules/fixes-url.js
+++ b/test/rules/fixes-url.js
@@ -4,29 +4,162 @@ const test = require('tap').test
 const Rule = require('../../lib/rules/fixes-url')
 const Commit = require('gitlint-parser-node')
 const Validator = require('../../')
-const INVALID_FIXES_URL = 'Fixes must be a url, not an issue number.'
+
+const INVALID_PRURL = 'Pull request URL must reference a comment or discussion.'
+const NOT_AN_ISSUE_NUMBER = 'Fixes must be a URL, not an issue number.'
+const NOT_A_GITHUB_URL = 'Fixes must be a GitHub URL.'
+const VALID_FIXES_URL = 'Valid fixes URL.'
+
+const makeCommit = (msg) => {
+  return new Commit({
+    sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea'
+  , author: {
+      name: 'Evan Lucas'
+    , email: 'evanlucas@me.com'
+    , date: '2016-04-12T19:42:23Z'
+    }
+  , message: msg
+  }, new Validator())
+}
 
 test('rule: fixes-url', (t) => {
-  t.test('invalid', (tt) => {
+  t.test('issue number', (tt) => {
     tt.plan(7)
-    const v = new Validator()
-    const context = new Commit({
-      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea'
-    , author: {
-        name: 'Evan Lucas'
-      , email: 'evanlucas@me.com'
-      , date: '2016-04-12T19:42:23Z'
-      }
-    , message: `test: fix something
+    const context = makeCommit(`test: fix something
 
 Fixes: #1234`
-    }, v)
+    )
 
     context.report = (opts) => {
       tt.pass('called report')
       tt.equal(opts.id, 'fixes-url', 'id')
-      tt.equal(opts.message, INVALID_FIXES_URL, 'message')
+      tt.equal(opts.message, NOT_AN_ISSUE_NUMBER, 'message')
       tt.equal(opts.string, '#1234', 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 7, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('GitHub issue URL', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/nodejs/node/issues/1234'
+    const context = makeCommit(`test: fix something
+
+Fixes: ${url}`
+    )
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'fixes-url', 'id')
+      tt.equal(opts.message, VALID_FIXES_URL, 'message')
+      tt.equal(opts.string, url, 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 7, 'column')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('GitHub issue URL with comment', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/nodejs/node/issues/1234#issuecomment-1234'
+    const context = makeCommit(`test: fix something
+
+Fixes: ${url}`
+    )
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'fixes-url', 'id')
+      tt.equal(opts.message, VALID_FIXES_URL, 'message')
+      tt.equal(opts.string, url, 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 7, 'column')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('GitHub PR URL', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/nodejs/node/pull/1234'
+    const context = makeCommit(`test: fix something
+
+Fixes: ${url}`
+    )
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'fixes-url', 'id')
+      tt.equal(opts.message, INVALID_PRURL, 'message')
+      tt.equal(opts.string, url, 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 7, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('GitHub PR URL with comment', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/nodejs/node/pull/1234#issuecomment-1234'
+    const context = makeCommit(`test: fix something
+
+Fixes: ${url}`
+    )
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'fixes-url', 'id')
+      tt.equal(opts.message, VALID_FIXES_URL, 'message')
+      tt.equal(opts.string, url, 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 7, 'column')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('GitHub PR URL with discussion comment', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/nodejs/node/pull/1234#discussion_r1234'
+    const context = makeCommit(`test: fix something
+
+Fixes: ${url}`
+    )
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'fixes-url', 'id')
+      tt.equal(opts.message, VALID_FIXES_URL, 'message')
+      tt.equal(opts.string, url, 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 7, 'column')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('non-GitHub URL', (tt) => {
+    tt.plan(7)
+    const context = makeCommit(`test: fix something
+
+Fixes: https://nodejs.org`
+    )
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'fixes-url', 'id')
+      tt.equal(opts.message, NOT_A_GITHUB_URL, 'message')
+      tt.equal(opts.string, 'https://nodejs.org', 'string')
       tt.equal(opts.line, 1, 'line')
       tt.equal(opts.column, 7, 'column')
       tt.equal(opts.level, 'fail', 'level')

--- a/test/rules/pr-url.js
+++ b/test/rules/pr-url.js
@@ -3,7 +3,9 @@
 const test = require('tap').test
 const Rule = require('../../lib/rules/pr-url')
 const MISSING_PR_URL = 'Commit must have a PR-URL.'
-const INVALID_PR_URL = 'PR-URL must be a url, not a pr number.'
+const INVALID_PR_URL = 'PR-URL must be a GitHub pull request URL.'
+const NUMERIC_PR_URL = 'PR-URL must be a URL, not a pull request number.'
+const VALID_PR_URL = 'PR-URL is valid.'
 
 test('rule: pr-url', (t) => {
   t.test('missing', (tt) => {
@@ -24,7 +26,8 @@ test('rule: pr-url', (t) => {
     Rule.validate(context)
   })
 
-  t.test('invalid', (tt) => {
+
+  t.test('invalid numeric', (tt) => {
     tt.plan(7)
     const context = {
       prUrl: '#1234'
@@ -35,11 +38,57 @@ test('rule: pr-url', (t) => {
     , report: (opts) => {
         tt.pass('called report')
         tt.equal(opts.id, 'pr-url', 'id')
-        tt.equal(opts.message, INVALID_PR_URL, 'message')
+        tt.equal(opts.message, NUMERIC_PR_URL, 'message')
         tt.equal(opts.string, '#1234', 'string')
         tt.equal(opts.line, 1, 'line')
         tt.equal(opts.column, 8, 'column')
         tt.equal(opts.level, 'fail', 'level')
+      }
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('invalid', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/nodejs/node/issues/1234'
+    const context = {
+      prUrl: url
+    , body: [
+        ''
+      , `PR-URL: ${url}`
+      ]
+    , report: (opts) => {
+        tt.pass('called report')
+        tt.equal(opts.id, 'pr-url', 'id')
+        tt.equal(opts.message, INVALID_PR_URL, 'message')
+        tt.equal(opts.string, url, 'string')
+        tt.equal(opts.line, 1, 'line')
+        tt.equal(opts.column, 8, 'column')
+        tt.equal(opts.level, 'fail', 'level')
+      }
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('valid', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/nodejs/node/pull/1234'
+    const context = {
+      prUrl: url
+    , body: [
+        ''
+      , `PR-URL: ${url}`
+      ]
+    , report: (opts) => {
+        tt.pass('called report')
+        tt.equal(opts.id, 'pr-url', 'id')
+        tt.equal(opts.message, VALID_PR_URL, 'message')
+        tt.equal(opts.string, url, 'string')
+        tt.equal(opts.line, 1, 'line')
+        tt.equal(opts.column, 8, 'column')
+        tt.equal(opts.level, 'pass', 'level')
       }
     }
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/26691#issuecomment-476350154

e.g. for https://github.com/nodejs/node/commit/bdea725bdcb299579547f66ebcc98af16f53cd16
```console
-bash-4.2$ node ../core-validate-commit/bin/cmd.js bdea725
  ✖  bdea725bdcb299579547f66ebcc98af16f53cd16
     ✖  4:7      Fixes must be a GitHub URL.               fixes-url
     ✔  5:7      Valid fixes URL.                          fixes-url
     ✔  0:0      blank line after title                    line-after-title
     ✔  0:0      line-lengths are valid                    line-length
     ✔  0:0      metadata is at end of message             metadata-end
     ✔  3:8      PR-URL is valid.                          pr-url
     ✔  0:0      reviewers are valid                       reviewers
     ✔  0:0      valid subsystems                          subsystem
     ✔  0:0      Title is formatted correctly.             title-format
     ⚠  0:50     Title should be <= 50 columns.            title-length
-bash-4.2$
```