### PR TITLE
rules: allow dashes in 'Fixes:' URL check

### DIFF
--- a/lib/rules/fixes-url.js
+++ b/lib/rules/fixes-url.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const id = 'fixes-url'
-const github = new RegExp('^https://github\.com/\\w+\/\\w+/' +
+const github = new RegExp('^https://github\.com/[\\w\\-]+\/[\\w\\-]+/' +
   '(issues|pull)/\\d+(#issuecomment-\\d+|#discussion_r\\d+)?$'
 )
 

--- a/test/rules/fixes-url.js
+++ b/test/rules/fixes-url.js
@@ -64,6 +64,27 @@ Fixes: ${url}`
     Rule.validate(context)
   })
 
+  t.test('GitHub issue URL with dash', (tt) => {
+    tt.plan(7)
+    const url = 'https://github.com/foo-bar/bar-baz/issues/1234'
+    const context = makeCommit(`test: fix something
+
+Fixes: ${url}`
+    )
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'fixes-url', 'id')
+      tt.equal(opts.message, VALID_FIXES_URL, 'message')
+      tt.equal(opts.string, url, 'string')
+      tt.equal(opts.line, 1, 'line')
+      tt.equal(opts.column, 7, 'column')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
   t.test('GitHub issue URL with comment', (tt) => {
     tt.plan(7)
     const url = 'https://github.com/nodejs/node/issues/1234#issuecomment-1234'


### PR DESCRIPTION
Before this commit, links to https://github.com/nodejs/node-gyp/issues
were rejected because of the dash in 'node-gyp'.

Notably, this fix means this commit log now passes validation. :-)

Bug introduced in commit 2523fb9 ("rules: stricter `Fixes:` URL check")
from March 30.

Fixes: https://github.com/nodejs/core-validate-commit/issues/60