### PR TITLE
subsystem: allow `gyp` as a subsystem

### DIFF
--- a/lib/rules/subsystem.js
+++ b/lib/rules/subsystem.js
@@ -11,6 +11,7 @@ const validSubsystems = [
 , 'errors'
 , 'etw'
 , 'esm'
+, 'gyp'
 , 'inspector'
 , 'lib'
 , 'loader'


### PR DESCRIPTION
`gyp:` has been used as subsystem tag 30 times for tools/gyp

See https://github.com/nodejs/node/pull/28573