### PR TITLE
bin: add a flag to list the subsystems

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -88,7 +88,7 @@ function loadPatch(uri, cb) {
 const v = new Validator(parsed)
 
 if (parsed['list-subsystems']) {
-  utils.describeSubsystem(subsystem.defaults.subsystems)
+  utils.describeSubsystem(subsystem.defaults.subsystems.sort())
   return
 }
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -14,12 +14,14 @@ const formatTap = require('../lib/format-tap')
 const Validator = require('../lib')
 const Tap = require('../lib/tap')
 const utils = require('../lib/utils')
+const subsystem = require('../lib/rules/subsystem')
 const knownOpts = { help: Boolean
 , version: Boolean
 , 'validate-metadata': Boolean
 , tap: Boolean
 , out: path
 , list: Boolean
+, 'list-subsystems': Boolean
 }
 const shortHand = { h: ['--help']
 , v: ['--version']
@@ -27,6 +29,7 @@ const shortHand = { h: ['--help']
 , t: ['--tap']
 , o: ['--out']
 , l: ['--list']
+, ls: ['--list-subsystems']
 }
 
 const parsed = nopt(knownOpts, shortHand)
@@ -83,6 +86,11 @@ function loadPatch(uri, cb) {
 }
 
 const v = new Validator(parsed)
+
+if (parsed['list-subsystems']) {
+  utils.describeSubsystem(subsystem.defaults.subsystems)
+  return
+}
 
 if (parsed.list) {
   const ruleNames = Array.from(v.rules.keys())

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -8,6 +8,7 @@ core-validate-commit - Validate the commit message for a particular commit in no
     -V, --validate-metadata       validate PR-URL and reviewers (on by default)
     -t, --tap                     output in tap format
     -l, --list                    list rules and their descriptions
+    -ls --list-subsystems         list the available subsystems
 
   examples:
     Validate a single sha:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,3 +45,16 @@ exports.describeRule = function describeRule(rule, max = 20) {
     console.log(' %s %s', chalk.red(title), chalk.dim(desc))
   }
 }
+
+exports.describeSubsystem = function describeSubsystem(subsystems, max = 20) {
+  if (subsystems) {
+    for (let sub = 0; sub < subsystems.length; sub++) {
+      console.log('%s %s %s',
+        chalk.green(exports.leftPad(subsystems[sub] || '', max)),
+        chalk.green(exports.leftPad(subsystems[sub+1] || '', max)),
+        chalk.green(exports.leftPad(subsystems[sub+2] || '', max))
+      )
+      sub += 2
+    }
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,13 +48,12 @@ exports.describeRule = function describeRule(rule, max = 20) {
 
 exports.describeSubsystem = function describeSubsystem(subsystems, max = 20) {
   if (subsystems) {
-    for (let sub = 0; sub < subsystems.length; sub++) {
+    for (let sub = 0; sub < subsystems.length; sub = sub + 3) {
       console.log('%s %s %s',
                   chalk.green(exports.leftPad(subsystems[sub] || '', max)),
                   chalk.green(exports.leftPad(subsystems[sub + 1] || '', max)),
                   chalk.green(exports.leftPad(subsystems[sub + 2] || '', max))
       )
-      sub += 2
     }
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,9 +50,9 @@ exports.describeSubsystem = function describeSubsystem(subsystems, max = 20) {
   if (subsystems) {
     for (let sub = 0; sub < subsystems.length; sub++) {
       console.log('%s %s %s',
-        chalk.green(exports.leftPad(subsystems[sub] || '', max)),
-        chalk.green(exports.leftPad(subsystems[sub+1] || '', max)),
-        chalk.green(exports.leftPad(subsystems[sub+2] || '', max))
+                  chalk.green(exports.leftPad(subsystems[sub] || '', max)),
+                  chalk.green(exports.leftPad(subsystems[sub + 1] || '', max)),
+                  chalk.green(exports.leftPad(subsystems[sub + 2] || '', max))
       )
       sub += 2
     }

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const test = require('tap').test
+const { spawn } = require('child_process')
+
+const outputText = `
+               assert           async_hooks             benchmark
+            bootstrap                buffer                 build
+        child_process               cluster               console
+            constants                crypto              debugger
+                 deps                 dgram                   dns
+                  doc                domain                errors
+                  esm                   etw                events
+                   fs                   gyp                  http
+                http2                 https             inspector
+            inspector                   lib                loader
+                 meta                module                   msi
+                n-api                   net                  node
+                   os                  path            perf_hooks
+              perfctr                policy               process
+             punycode           querystring                  quic
+             readline                  repl                report
+                  src                stream        string_decoder
+                  sys                  test                timers
+                  tls                 tools          trace_events
+                  tty                   url                  util
+                   v8                    vm                   win
+               worker                  zlib`
+
+test('Test cli flags', (t) => {
+  t.test('test list-subsystems', (tt) => {
+    const ls = spawn('./bin/cmd.js', ['--list-subsystems'])
+    let compiledData = ''
+    ls.stdout.on('data', (data) => {
+      compiledData += data
+    })
+
+    ls.stderr.on('data', (data) => {
+      tt.fail('This should not happen')
+    })
+
+    ls.on('close', (code) => {
+      tt.equal(compiledData.trim(),
+               outputText.trim(),
+               'Should output the list to the console')
+      tt.end()
+    })
+  })
+
+  t.end()
+})

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,31 +1,8 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('tap')
 const { spawn } = require('child_process')
-
-const outputText = `
-               assert           async_hooks             benchmark
-            bootstrap                buffer                 build
-        child_process               cluster               console
-            constants                crypto              debugger
-                 deps                 dgram                   dns
-                  doc                domain                errors
-                  esm                   etw                events
-                   fs                   gyp                  http
-                http2                 https             inspector
-            inspector                   lib                loader
-                 meta                module                   msi
-                n-api                   net                  node
-                   os                  path            perf_hooks
-              perfctr                policy               process
-             punycode           querystring                  quic
-             readline                  repl                report
-                  src                stream        string_decoder
-                  sys                  test                timers
-                  tls                 tools          trace_events
-                  tty                   url                  util
-                   v8                    vm                   win
-               worker                  zlib`
+const subsystems = require('../lib/rules/subsystem')
 
 test('Test cli flags', (t) => {
   t.test('test list-subsystems', (tt) => {
@@ -40,9 +17,25 @@ test('Test cli flags', (t) => {
     })
 
     ls.on('close', (code) => {
-      tt.equal(compiledData.trim(),
-               outputText.trim(),
-               'Should output the list to the console')
+      // Get the list of subsytems as an Array.
+      // Need to match words that also have the "-" in them
+      const subsystemsFromOutput = compiledData.match(/[\w'-]+/g)
+      const defaultSubsystems = subsystems.defaults.subsystems
+
+      tt.equal(subsystemsFromOutput.length,
+               defaultSubsystems.length,
+               'Should have the same length')
+
+      // Loop through the output list and compare with the real list
+      // to make sure they are all there
+      const missing = []
+      subsystemsFromOutput.forEach((sub) => {
+        if (!defaultSubsystems.find((x) => {return x === sub})) {
+          missing.push(sub)
+        }
+      })
+
+      tt.equal(missing.length, 0, 'Should have no missing subsystems')
       tt.end()
     })
   })


### PR DESCRIPTION
This commit adds the flag --list-subsystems to list all the subsystems that are available for use.

fixes #66


Since the output is rather long is just listing in one column, so i'm using 3 columns when doing the listing.