### PR TITLE
Refactor of the cmd.js - Still a WIP, but looking for comments

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -73,10 +73,14 @@ if (parsed.list) {
 
 // The --tap or -t flag was used
 if (parsed.tap) {
-  utils.parseTap(v, parsed, args)
-  return
+  utils.parseTap(v, parsed, args, (code) => {
+    process.exitCode = code
+    return
+  })
 } else {
   // no --flags used,  defaults to --validate-metadata
-  utils.validateMetadata(v, args)
-  return
+  utils.validateMetadata(v, args, (code) => {
+    process.exitCode = code
+    return
+  })
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -5,7 +5,6 @@
 const fs = require('fs')
 const nopt = require('nopt')
 const path = require('path')
-const pretty = require('../lib/format-pretty')
 const formatTap = require('../lib/format-tap')
 const Validator = require('../lib')
 const Tap = require('../lib/tap')
@@ -110,22 +109,6 @@ if (parsed.tap) {
 
 } else {
   // no --flags used,  defaults to --validate-metadata
-  v.on('commit', (c) => {
-    pretty(c.commit, c.messages, v)
-    run()
-  })
-
-  function run() {
-    if (!args.length) {
-      process.exitCode = v.errors
-      return
-    }
-    const sha = args.shift()
-    utils.load(sha, (err, data) => {
-      if (err) throw err
-      v.lint(data)
-    })
-  }
-
-  run()
+  utils.validateMetadata(v, args)
+  return
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -46,6 +46,12 @@ if (parsed.version) {
   return
 }
 
+// The --list-subsytems or --ls flag was used
+if (parsed['list-subsystems']) {
+  utils.describeSubsystem(subsystem.defaults.subsystems.sort())
+  return
+}
+
 // any arguments after a --flag will be in the remain array
 const args = parsed.argv.remain
 
@@ -97,12 +103,6 @@ function loadPatch(uri, cb) {
 
 // Create a new Validator
 const v = new Validator(parsed)
-
-// The --list-subsytems or --ls flag was used
-if (parsed['list-subsystems']) {
-  utils.describeSubsystem(subsystem.defaults.subsystems.sort())
-  return
-}
 
 // The --list or -l flag was used
 if (parsed.list) {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -2,12 +2,9 @@
 
 'use strict'
 
-const fs = require('fs')
 const nopt = require('nopt')
 const path = require('path')
-const formatTap = require('../lib/format-tap')
 const Validator = require('../lib')
-const Tap = require('../lib/tap')
 const utils = require('../lib/utils')
 const subsystem = require('../lib/rules/subsystem')
 const knownOpts = { help: Boolean
@@ -76,37 +73,8 @@ if (parsed.list) {
 
 // The --tap or -t flag was used
 if (parsed.tap) {
-  const tap = new Tap()
-  tap.pipe(process.stdout)
-  if (parsed.out) tap.pipe(fs.createWriteStream(parsed.out))
-  let count = 0
-  let total = args.length
-
-  v.on('commit', (c) => {
-    count++
-    const test = tap.test(c.commit.sha)
-    formatTap(test, c.commit, c.messages, v)
-    if (count === total) {
-      setImmediate(() => {
-        tap.end()
-        if (tap.status === 'fail')
-          process.exitCode = 1
-      })
-    }
-  })
-
-  function run() {
-    if (!args.length) return
-    const sha = args.shift()
-    utils.load(sha, (err, data) => {
-      if (err) throw err
-      v.lint(data)
-      run()
-    })
-  }
-
-  run()
-
+  utils.parseTap(v, parsed, args)
+  return
 } else {
   // no --flags used,  defaults to --validate-metadata
   utils.validateMetadata(v, args)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,7 +107,7 @@ exports.loadPatch = function loadPatch(uri, cb) {
   }).on('error', cb)
 }
 
-exports.validateMetadata = function(validator, args) {
+exports.validateMetadata = function(validator, args, cb) {
   validator.on('commit', (c) => {
     pretty(c.commit, c.messages, validator)
     run()
@@ -115,8 +115,7 @@ exports.validateMetadata = function(validator, args) {
 
   function run() {
     if (!args.length) {
-      process.exitCode = validator.errors
-      return
+      return cb(validator.errors)
     }
     const sha = args.shift()
     exports.load(sha, (err, data) => {
@@ -128,7 +127,7 @@ exports.validateMetadata = function(validator, args) {
   run()
 }
 
-exports.parseTap = function(validator, parsed, args) {
+exports.parseTap = function(validator, parsed, args, cb) {
   const tap = new Tap()
   tap.pipe(process.stdout)
   if (parsed.out) tap.pipe(fs.createWriteStream(parsed.out))
@@ -142,8 +141,11 @@ exports.parseTap = function(validator, parsed, args) {
     if (count === total) {
       setImmediate(() => {
         tap.end()
-        if (tap.status === 'fail')
-          process.exitCode = 1
+        if (tap.status === 'fail') {
+          return cb(1)
+        }
+
+        return cb(0)
       })
     }
   })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const exec = require('child_process').exec
+const http = require('http')
+const https = require('https')
+const url = require('url')
 const chalk = require('chalk')
 const CHECK = chalk.green('✔')
 const X = chalk.red('✖')
@@ -56,4 +60,45 @@ exports.describeSubsystem = function describeSubsystem(subsystems, max = 20) {
       )
     }
   }
+}
+
+// Given a commit hash, load it
+// If a URL is passed in, then load the commit remotely
+// If not, then do a git show
+exports.load = function load(sha, cb) {
+  const parsed = url.parse(sha)
+  if (parsed.protocol) {
+    return exports.loadPatch(parsed, cb)
+  }
+
+  exec(`git show --quiet --format=medium ${sha}`, (err, stdout, stderr) => {
+    if (err) return cb(err)
+    cb(null, stdout.trim())
+  })
+}
+
+// Load the commit from a URL
+exports.loadPatch = function loadPatch(uri, cb) {
+  let h = http
+  if (~uri.protocol.indexOf('https')) {
+    h = https
+  }
+  uri.headers = {
+    'user-agent': 'core-validate-commit'
+  }
+  h.get(uri, (res) => {
+    let buf = ''
+    res.on('data', (chunk) => {
+      buf += chunk
+    })
+
+    res.on('end', () => {
+      try {
+        const out = JSON.parse(buf)
+        cb(null, out)
+      } catch (err) {
+        cb(err)
+      }
+    })
+  }).on('error', cb)
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,12 @@
 'use strict'
 
+const fs = require('fs')
 const exec = require('child_process').exec
 const http = require('http')
 const https = require('https')
 const url = require('url')
+const formatTap = require('../lib/format-tap')
+const Tap = require('../lib/tap')
 const pretty = require('../lib/format-pretty')
 const chalk = require('chalk')
 const CHECK = chalk.green('✔')
@@ -119,6 +122,39 @@ exports.validateMetadata = function(validator, args) {
     exports.load(sha, (err, data) => {
       if (err) throw err
       validator.lint(data)
+    })
+  }
+
+  run()
+}
+
+exports.parseTap = function(validator, parsed, args) {
+  const tap = new Tap()
+  tap.pipe(process.stdout)
+  if (parsed.out) tap.pipe(fs.createWriteStream(parsed.out))
+  let count = 0
+  let total = args.length
+
+  validator.on('commit', (c) => {
+    count++
+    const test = tap.test(c.commit.sha)
+    formatTap(test, c.commit, c.messages, validator)
+    if (count === total) {
+      setImmediate(() => {
+        tap.end()
+        if (tap.status === 'fail')
+          process.exitCode = 1
+      })
+    }
+  })
+
+  function run() {
+    if (!args.length) return
+    const sha = args.shift()
+    exports.load(sha, (err, data) => {
+      if (err) throw err
+      validator.lint(data)
+      run()
     })
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ const exec = require('child_process').exec
 const http = require('http')
 const https = require('https')
 const url = require('url')
+const pretty = require('../lib/format-pretty')
 const chalk = require('chalk')
 const CHECK = chalk.green('✔')
 const X = chalk.red('✖')
@@ -101,4 +102,25 @@ exports.loadPatch = function loadPatch(uri, cb) {
       }
     })
   }).on('error', cb)
+}
+
+exports.validateMetadata = function(validator, args) {
+  validator.on('commit', (c) => {
+    pretty(c.commit, c.messages, validator)
+    run()
+  })
+
+  function run() {
+    if (!args.length) {
+      process.exitCode = validator.errors
+      return
+    }
+    const sha = args.shift()
+    exports.load(sha, (err, data) => {
+      if (err) throw err
+      validator.lint(data)
+    })
+  }
+
+  run()
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "check-pkg": "^2.0.2",
     "lintit": "^6.0.1",
+    "nock": "~10.0.6",
+    "proxyquire": "^2.1.1",
     "tap": "^12.6.1"
   },
   "files": [

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,104 @@
+'use strict'
+
+const { test } = require('tap')
+const proxyquire = require('proxyquire')
+const nock = require('nock')
+
+const commitHash = 'a12b34c56'
+
+test('Test util functions', (t) => {
+  t.test('test sha load function', (tt) => {
+    const commitMessage = 'Commit Message'
+
+    const utils = proxyquire('../lib/utils', {
+      'child_process': {
+        exec: (cmd, cb) => {
+          tt.equals(cmd,
+                    `git show --quiet --format=medium ${commitHash}`,
+                    'cmd should be equal')
+          cb(null, commitMessage)
+        }
+      }
+    })
+
+    utils.load(commitHash, (err, stdout, stderr) => {
+      tt.equals(err, null, 'Should not be an error')
+      tt.equals(commitMessage, stdout, 'should have the commit message')
+      tt.end()
+    })
+  })
+
+  t.test('test sha load function with error', (tt) => {
+    const utils = proxyquire('../lib/utils', {
+      'child_process': {
+        exec: (cmd, cb) => {
+          cb('Error', null)
+        }
+      }
+    })
+
+    utils.load(commitHash, (err, stdout, stderr) => {
+      tt.equals(err, 'Error', 'should have the error message')
+      tt.end()
+    })
+  })
+
+  t.test('test load patch function using http', (tt) => {
+    const commitUrl = `http://api.github.com/repos/nodejs/${commitHash}`
+    const util = require('../lib/utils')
+
+    nock('http://api.github.com', {
+      reqheaders: {
+        'user-agent': 'core-validate-commit'
+      }
+    })
+      .get(`/repos/nodejs/${commitHash}`)
+      .reply(200, {commit: 'message'})
+
+    util.load(commitUrl, (err, commitMessage) => {
+      tt.equals(err, null, 'Should not be an error')
+      tt.pass()
+      tt.end()
+    })
+  })
+
+  t.test('test load patch function using https', (tt) => {
+    const commitUrl = `https://api.github.com/repos/nodejs/${commitHash}`
+    const util = require('../lib/utils')
+
+    nock('https://api.github.com', {
+      reqheaders: {
+        'user-agent': 'core-validate-commit'
+      }
+    })
+      .get(`/repos/nodejs/${commitHash}`)
+      .reply(200, {commit: 'message'})
+
+    util.load(commitUrl, (err, commitMessage) => {
+      tt.equals(err, null, 'Should not be an error')
+      tt.pass()
+      tt.end()
+    })
+  })
+
+  t.test('test load patch function - catch parse error', (tt) => {
+    const commitUrl = `http://api.github.com/repos/nodejs/${commitHash}`
+    const util = require('../lib/utils')
+
+    nock('http://api.github.com', {
+      reqheaders: {
+        'user-agent': 'core-validate-commit'
+      }
+    })
+      .get(`/repos/nodejs/${commitHash}`)
+      .reply(200, '{commit: \'message\'}')
+
+    util.load(commitUrl, (err, commitMessage) => {
+      tt.true(err)
+      tt.pass()
+      tt.end()
+    })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
This PR is a work in progress to discuss the refactor discussed in #71 .  The goal is to refactor the cmd.js file to not be cluttered with the actual logic of what a command does, which should help in being able to test it easier.

I've tried to keep the commits logically separated.

In the first commit, I've just added comments on what is actually happening.  This was more for me to understand what is going on where.  

The second commit just moves the logic for the `--list-subsystem` flag up a little in the code.  not really a functional change, but more for style.

Commits 3 and 4 are related to moving the load and loadPatch functions from the cmd.js file to the utils module.  Moving them into the utils module, and exporting them, i was able to write tests for them as standalone functions.  It also adds 2 new dev dependecies, proxyquire and nock. 

The next 2 commits are related to moving the logic for the `--validate-metadata` and `--tap` commands out, and into the utils module.  Moving the logic out into its own function, i have to pass in a `Validator` object, which will make it easier to mock and test

I still need to write tests for these 2 functions, but I think now it will be easier to do so.

I just wanted to start this PR to have a discussion if what i'm doing and suggesting makes sense. 
