### PR TITLE
test: add tests for header util functions

### DIFF
--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -3,6 +3,10 @@
 const { test } = require('tap')
 const utils = require('../lib/utils')
 
+// We aren't testing the chalk library, so strip off the colors/styles it adds
+const stripAnsiRegex =
+/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
+
 test('test utility functions', (t) => {
   t.test('test rightPad function - with padding', (tt) => {
     const padded = utils.rightPad('string', 10)
@@ -33,6 +37,38 @@ test('test utility functions', (t) => {
     tt.equal(padded.length, 6, 'should have the same length')
     tt.equal(padded, 'string', 'should have no padding on the left')
 
+    tt.end()
+  })
+
+  t.test('test headers function - skip', (tt) => {
+    const header = utils.header('abc123', 'skip')
+    tt.equal(header.replace(stripAnsiRegex, ''),
+             '✔  abc123 # SKIPPED',
+             'should be equal')
+    tt.end()
+  })
+
+  t.test('test headers function - pass', (tt) => {
+    const header = utils.header('abc123', 'pass')
+    tt.equal(header.replace(stripAnsiRegex, ''),
+             '✔  abc123',
+             'should be equal')
+    tt.end()
+  })
+
+  t.test('test headers function - pass', (tt) => {
+    const header = utils.header('abc123', 'pass')
+    tt.equal(header.replace(stripAnsiRegex, ''),
+             '✔  abc123',
+             'should be equal')
+    tt.end()
+  })
+
+  t.test('test headers function - fail', (tt) => {
+    const header = utils.header('abc123', 'fail')
+    tt.equal(header.replace(stripAnsiRegex, ''),
+             '✖  abc123',
+             'should be equal')
     tt.end()
   })
 


### PR DESCRIPTION
* This adds a test for the header utility function.

This one was a little interesting, since the outputs where being styled.  In the tests, i've stripped off the ansi encoding, since we aren't really trying to test that chalk worked, we are just interested in the "normal" string output

I'm sending this PR first, before i send the PR that tests the last 2 functions in this file, since they also have output styled with chalk.  And if what i did here is ok, then i'll send that one also