### PR TITLE
lib: add cli to valid subsystems

### DIFF
--- a/lib/rules/subsystem.js
+++ b/lib/rules/subsystem.js
@@ -6,6 +6,7 @@ const validSubsystems = [
   'benchmark'
 , 'build'
 , 'bootstrap'
+, 'cli',
 , 'deps'
 , 'doc'
 , 'errors'

--- a/lib/rules/subsystem.js
+++ b/lib/rules/subsystem.js
@@ -6,7 +6,7 @@ const validSubsystems = [
   'benchmark'
 , 'build'
 , 'bootstrap'
-, 'cli',
+, 'cli'
 , 'deps'
 , 'doc'
 , 'errors'


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/30094.

Adds `cli` to the list of valid subsystems.

cc @addaleax 