### PR TITLE
travis: update for Node.js 12 and 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "11"
+  - "12"
+  - "13"
 cache: npm
 script: 'npm run test-ci'
 after_script: 'bash <(curl -s https://codecov.io/bash)'


### PR DESCRIPTION
Add latest current and LTS. Drop Node.js 11.