### PR TITLE
lib: add wasm subsystem

### DIFF
--- a/lib/rules/subsystem.js
+++ b/lib/rules/subsystem.js
@@ -25,6 +25,7 @@ const validSubsystems = [
 , 'src'
 , 'test'
 , 'tools'
+, 'wasm'
 , 'win'
 
   // core libs

--- a/lib/rules/subsystem.js
+++ b/lib/rules/subsystem.js
@@ -70,6 +70,7 @@ const validSubsystems = [
 , 'util'
 , 'v8'
 , 'vm'
+, 'wasi'
 , 'worker'
 , 'zlib'
 ]


### PR DESCRIPTION
It would be useful to have a generic Web Assembly dedicated subsystem at this point, which also will allow us to handle WASI as well until we have its builtin name set.