### PR TITLE
lib: rename n-api to node-api

### DIFF
--- a/lib/rules/subsystem.js
+++ b/lib/rules/subsystem.js
@@ -19,7 +19,7 @@ const validSubsystems = [
   'meta',
   'msi',
   'node',
-  'n-api',
+  'node-api',
   'perfctr',
   'policy',
   'src',


### PR DESCRIPTION
`n-api` shall no longer be accepted as a subsystem. Instead, the
accepted name for it shall be `node-api`.

Refs: https://github.com/nodejs/abi-stable-node/issues/420