### PR TITLE
Fix regressions from refactoring

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,6 +20,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Need commit history test for cli-tests
+        fetch-depth: 0
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -50,15 +50,15 @@ const args = parsed.argv.remain
 if (!args.length) { args.push('HEAD') }
 
 function load (sha, cb) {
-  const parsed = new URL(sha)
-  if (parsed.protocol) {
+  try {
+    const parsed = new URL(sha)
     return loadPatch(parsed, cb)
+  } catch (_) {
+    exec(`git show --quiet --format=medium ${sha}`, (err, stdout, stderr) => {
+      if (err) return cb(err)
+      cb(null, stdout.trim())
+    })
   }
-
-  exec(`git show --quiet --format=medium ${sha}`, (err, stdout, stderr) => {
-    if (err) return cb(err)
-    cb(null, stdout.trim())
-  })
 }
 
 function loadPatch (uri, cb) {
@@ -66,10 +66,10 @@ function loadPatch (uri, cb) {
   if (~uri.protocol.indexOf('https')) {
     h = https
   }
-  uri.headers = {
+  const headers = {
     'user-agent': 'core-validate-commit'
   }
-  h.get(uri, (res) => {
+  h.get(uri, { headers }, (res) => {
     let buf = ''
     res.on('data', (chunk) => {
       buf += chunk

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -38,7 +38,6 @@ const usage = require('help')()
 
 if (parsed.help) {
   usage()
-  process.exit(0)
 }
 
 if (parsed.version) {
@@ -47,7 +46,7 @@ if (parsed.version) {
 }
 
 const args = parsed.argv.remain
-if (!args.length) { args.push('HEAD') }
+if (!parsed.help && !args.length) { args.push('HEAD') }
 
 function load (sha, cb) {
   try {

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const { test } = require('tap')
+const { readFileSync } = require('fs')
 const { spawn } = require('child_process')
 const subsystems = require('../lib/rules/subsystem')
 
 test('Test cli flags', (t) => {
   t.test('test list-subsystems', (tt) => {
     const ls = spawn('./bin/cmd.js', ['--list-subsystems'], {
-      env: { FORCE_COLOR: 0 }
+      env: { ...process.env, FORCE_COLOR: 0 }
     })
     let compiledData = ''
     ls.stdout.on('data', (data) => {
@@ -38,6 +39,26 @@ test('Test cli flags', (t) => {
       })
 
       tt.equal(missing.length, 0, 'Should have no missing subsystems')
+      tt.end()
+    })
+  })
+
+  t.test('test help output', (tt) => {
+    const usage = readFileSync('bin/usage.txt', { encoding: 'utf8' })
+    const ls = spawn('./bin/cmd.js', ['--help'])
+    let compiledData = ''
+    ls.stdout.on('data', (data) => {
+      compiledData += data
+    })
+
+    ls.stderr.on('data', (data) => {
+      tt.fail('This should not happen')
+    })
+
+    ls.on('close', (code) => {
+      tt.equal(compiledData.trim(),
+        usage.trim(),
+        '--help output is as expected')
       tt.end()
     })
   })

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -42,6 +42,44 @@ test('Test cli flags', (t) => {
     })
   })
 
+  t.test('test sha', (tt) => {
+    const ls = spawn('./bin/cmd.js', ['--no-validate-metadata', '2b98d02b52'])
+    let compiledData = ''
+    ls.stdout.on('data', (data) => {
+      compiledData += data
+    })
+
+    ls.stderr.on('data', (data) => {
+      tt.fail('This should not happen')
+    })
+
+    ls.on('close', (code) => {
+      tt.match(compiledData.trim(),
+        /2b98d02b52/,
+        'output is as expected')
+      tt.end()
+    })
+  })
+
+  t.test('test url', (tt) => {
+    const ls = spawn('./bin/cmd.js', ['--no-validate-metadata', 'https://api.github.com/repos/nodejs/core-validate-commit/commits/2b98d02b52'])
+    let compiledData = ''
+    ls.stdout.on('data', (data) => {
+      compiledData += data
+    })
+
+    ls.stderr.on('data', (data) => {
+      tt.fail('This should not happen')
+    })
+
+    ls.on('close', (code) => {
+      tt.match(compiledData.trim(),
+        /2b98d02b52/,
+        'output is as expected')
+      tt.end()
+    })
+  })
+
   t.test('test version flag', (tt) => {
     const ls = spawn('./bin/cmd.js', ['--version'])
     let compiledData = ''


### PR DESCRIPTION
The refactoring done under https://github.com/nodejs/core-validate-commit/pull/84 introduced some regressions. Fix those and add tests.

- bin: fix URL parsing
`new URL()` throws an exception when failing to parse a URL.

- bin: wait for help output
The `help` module asynchronously pipes output to streams. Do not
explicitly `process.exit` to allow the asynchronous operation to
complete.

Refs: https://github.com/nodejs/core-validate-commit/pull/84