### PR TITLE
feat: point to guidelines on failure in TAP output

### DIFF
--- a/lib/tap.js
+++ b/lib/tap.js
@@ -112,6 +112,8 @@ module.exports = class Tap extends Readable {
 
     if (this._failures) {
       this.write(`# fail  ${this._failures}`)
+      this.write('# Please review the commit message guidelines:')
+      this.write('# https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines')
     }
 
     this.push(null)


### PR DESCRIPTION
If commit linting fails, include the URL to the commit message
guidelines in the TAP output.

Refs: https://github.com/nodejs/node/issues/41697

This will output, e.g. 
```
# 86c832519452f74a1c4a701ec086509847d2485f
ok 1 co-authored-by-is-trailer: no Co-authored-by metadata
ok 2 fixes-url: skipping fixes-url # SKIP
ok 3 line-after-title: blank line after title
ok 4 line-length: line-lengths are valid
not ok 5 subsystem: Invalid subsystem: "feat" (feat: point to guidelines on failure in TAP output)
  ---
    {
      found: 'feat: point to guidelines on failure in TAP output',
      compare: 'indexOf() !== -1',
      wanted: [
        'benchmark',      'build',    'bootstrap',   'cli',
        'deps',           'doc',      'errors',      'etw',
        'esm',            'gyp',      'inspector',   'lib',
        'loader',         'meta',     'msi',         'node',
        'node-api',       'perfctr',  'policy',      'src',
        'test',           'tools',    'typings',     'wasm',
        'win',            'assert',   'async_hooks', 'buffer',
        'child_process',  'cluster',  'console',     'constants',
        'crypto',         'debugger', 'dgram',       'dns',
        'domain',         'events',   'fs',          'http',
        'http2',          'https',    'inspector',   'module',
        'net',            'os',       'path',        'perf_hooks',
        'process',        'punycode', 'querystring', 'quic',
        'readline',       'repl',     'report',      'stream',
        'string_decoder', 'sys',      'timers',      'tls',
        'trace_events',   'tty',      'url',         'util',
        'v8',             'vm',       'wasi',        'worker',
        'zlib'
      ],
      at: { line: 0, column: 0, body: undefined }
    }
  ...
ok 6 title-format: Title is formatted correctly.
ok 7 title-length: Title is <= 50 columns.

0..7
# tests 7
# pass  5
# fail  1
# Please review the commit message guidelines:
# https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines
```

When clicking on "Details" for a failed GitHub actions check the URL has `?check_suite_focus=true` appended, e.g. https://github.com/nodejs/node/runs/4741156729?check_suite_focus=true, which automatically expands the failing part of the workflow so this additional output will be immediately above the `Error: Process completed with exit code 123.` in the expanded output.