### PR TITLE
rules: accept revert commit titles that were elongated by git

### DIFF
--- a/lib/rules/title-length.js
+++ b/lib/rules/title-length.js
@@ -17,7 +17,8 @@ module.exports = {
     max_length: 72
   },
   validate: (context, rule) => {
-    const max = rule.options.max_length
+    const isRevertCommit = /^Revert ".*"$/.test(context.title)
+    const max = rule.options.max_length + (isRevertCommit ? 'Revert ""'.length : 0)
     if (context.title.length > max) {
       context.report({
         id: id,
@@ -31,7 +32,7 @@ module.exports = {
       return
     }
 
-    const len = rule.options.length
+    const len = rule.options.length + (isRevertCommit ? 'Revert ""'.length : 0)
     if (context.title.length > len) {
       context.report({
         id: id,


### PR DESCRIPTION
This change ensures that the commit message linter doesn't reject
revert commits that originally had commit titles with an acceptable
length but were elongated during the revert process by running
`git revert`.

Fixes: https://github.com/nodejs/core-validate-commit/issues/97
Signed-off-by: Darshan Sen <raisinten@gmail.com>