### PR TITLE
rules: accept "deps: V8" as the subsystem for revert commits

### DIFF
--- a/lib/rules/title-format.js
+++ b/lib/rules/title-format.js
@@ -9,8 +9,13 @@ module.exports = {
     recommended: true
   },
   validate: (context, rule) => {
+    const isRevertCommit = /^Revert ".*"$/.test(context.title)
+    const revertPrefixLength = 'Revert "'.length
+    const titleWithoutRevertPrefix = isRevertCommit
+      ? context.title.substr(revertPrefixLength,
+        context.title.length - revertPrefixLength - 1) : context.title
     let pass = true
-    if (/[.?!]$/.test(context.title)) {
+    if (/[.?!]$/.test(titleWithoutRevertPrefix)) {
       context.report({
         id: id,
         message: 'Do not use punctuation at end of title.',
@@ -23,7 +28,7 @@ module.exports = {
     }
 
     {
-      const result = /^([^:]+:)[^ ]/.exec(context.title)
+      const result = /^([^:]+:)[^ ]/.exec(titleWithoutRevertPrefix)
       if (result) {
         context.report({
           id: id,
@@ -38,7 +43,7 @@ module.exports = {
     }
 
     {
-      const result = /\s\s/.exec(context.title)
+      const result = /\s\s/.exec(titleWithoutRevertPrefix)
       if (result) {
         context.report({
           id: id,
@@ -52,9 +57,9 @@ module.exports = {
       }
     }
 
-    const isV8 = context.title.startsWith('deps: V8:')
+    const isV8 = titleWithoutRevertPrefix.startsWith('deps: V8:')
     if (!isV8) {
-      const result = /^([^:]+?): [A-Z]/.exec(context.title)
+      const result = /^([^:]+?): [A-Z]/.exec(titleWithoutRevertPrefix)
       if (result) {
         context.report({
           id: id,

--- a/test/validator.js
+++ b/test/validator.js
@@ -163,6 +163,15 @@ Date:   Sun May 1 21:10:21 2022 +0530
     Reviewed-By: Antoine du Hamel <duhamelantoine1995@gmail.com>
 `
 
+const str12 = `commit cbb404503c9df13aaeb3dd8b345cb3f34c8c07e4
+Author: Michaël Zasso <targos@protonmail.com>
+Date:   Sat Oct 22 10:22:43 2022 +0200
+
+    Revert "deps: V8: forward declaration of \`Rtl*FunctionTable\`"
+
+    This reverts commit 01bc8e6fd81314e76c7fb0d09e5310f609e48bee.
+`
+
 test('Validator - misc', (t) => {
   const v = new Validator()
 
@@ -290,6 +299,26 @@ test('Validator - real commits', (t) => {
       })
       const exp = ['title-length']
       tt.deepEqual(ids.sort(), exp.sort(), 'message ids')
+      tt.end()
+    })
+  })
+
+  t.test('accept deps: V8 as the subsystem for revert commits', (tt) => {
+    const v = new Validator({
+      'validate-metadata': false
+    })
+    v.lint(str12)
+    v.on('commit', (data) => {
+      const c = data.commit.toJSON()
+      tt.equal(c.sha, 'cbb404503c9df13aaeb3dd8b345cb3f34c8c07e4', 'sha')
+      tt.equal(c.date, 'Sat Oct 22 10:22:43 2022 +0200', 'date')
+      tt.deepEqual(c.subsystems, ['deps'], 'subsystems')
+      tt.equal(c.revert, true, 'revert')
+      const msgs = data.messages
+      const filtered = msgs.filter((item) => {
+        return item.level === 'fail'
+      })
+      tt.equal(filtered.length, 0, 'messages.length')
       tt.end()
     })
   })


### PR DESCRIPTION
The commit, https://github.com/nodejs/node/pull/45119/commits/cbb404503c9df13aaeb3dd8b345cb3f34c8c07e4, was being flagged as invalid by core-validate-commit because of this error:
```txt
Error: not ok 6 title-format: First word after subsystem(s) in title should be lowercase. (Revert "deps: V8: forward declaration of `Rtl*FunctionTable`")
```
This is incorrect because "deps: V8" is a valid subsystem. This change makes sure that revert commits with such a subsystem is accepted.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @targos 