### PR TITLE
rules: add `sea` to subsystem

### DIFF
--- a/lib/rules/subsystem.js
+++ b/lib/rules/subsystem.js
@@ -23,6 +23,7 @@ const validSubsystems = [
   'perfctr',
   'permission',
   'policy',
+  'sea',
   'src',
   'test',
   'tools',


### PR DESCRIPTION
So that `sea: ...` can be used as the commit subjects of single-executable PRs in the https://github.com/nodejs/node repo.

cc @nodejs/single-executable