### PR TITLE
feat: add `--validate-no-metadata` flag

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -17,6 +17,7 @@ const knownOpts = {
   help: Boolean,
   version: Boolean,
   'validate-metadata': Boolean,
+  'validate-no-metadata': Boolean,
   tap: Boolean,
   out: path,
   list: Boolean,

--- a/lib/rules/pr-url.js
+++ b/lib/rules/pr-url.js
@@ -10,6 +10,17 @@ export default {
   defaults: {},
   options: {},
   validate: (context, rule) => {
+    if (rule.options.expectsMissing) {
+      context.report({
+        id,
+        message: 'Commit must not have a PR-URL.',
+        string: context.prUrl,
+        line: 0,
+        column: 0,
+        level: context.prUrl ? 'fail' : 'pass'
+      })
+      return
+    }
     if (!context.prUrl) {
       context.report({
         id,

--- a/lib/rules/reviewers.js
+++ b/lib/rules/reviewers.js
@@ -21,6 +21,16 @@ export default {
       return
     }
 
+    if (rule.options.expectsMissing) {
+      return context.report({
+        id,
+        message: 'Commit must not have any reviewer.',
+        string: null,
+        line: 0,
+        column: 0,
+        level: parsed.reviewers.length ? 'fail' : 'pass'
+      })
+    }
     if (!Array.isArray(parsed.reviewers) || !parsed.reviewers.length) {
       // See nodejs/node#5aac4c42da104c30d8f701f1042d61c2f06b7e6c
       // for an example

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -47,7 +47,10 @@ export default class ValidateCommit extends EE {
     for (const key of keys) {
       this.rules.set(key, new BaseRule(RULES[key]))
     }
-    if (!this.opts['validate-metadata']) {
+    if (this.opts['validate-no-metadata']) {
+      this.rules.get('pr-url').options.expectsMissing = true
+      this.rules.get('reviewers').options.expectsMissing = true
+    } else if (!this.opts['validate-metadata']) {
       this.disableRule('pr-url')
       this.disableRule('reviewers')
       this.disableRule('metadata-end')

--- a/test/rules/pr-url.js
+++ b/test/rules/pr-url.js
@@ -21,7 +21,7 @@ test('rule: pr-url', (t) => {
       }
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.test('invalid numeric', (tt) => {
@@ -43,7 +43,7 @@ test('rule: pr-url', (t) => {
       }
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.test('invalid', (tt) => {
@@ -66,7 +66,7 @@ test('rule: pr-url', (t) => {
       }
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.test('valid', (tt) => {
@@ -89,7 +89,7 @@ test('rule: pr-url', (t) => {
       }
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.test('valid URL containing hyphen', (tt) => {
@@ -112,7 +112,7 @@ test('rule: pr-url', (t) => {
       }
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.test('valid URL with trailing slash', (tt) => {
@@ -135,7 +135,7 @@ test('rule: pr-url', (t) => {
       }
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.end()

--- a/test/rules/reviewers.js
+++ b/test/rules/reviewers.js
@@ -30,7 +30,7 @@ This is a test`
       tt.equal(opts.level, 'fail', 'level')
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.test('skip for release commit', (tt) => {
@@ -58,7 +58,7 @@ This is a test`
       })
     }
 
-    Rule.validate(context)
+    Rule.validate(context, { options: {} })
   })
 
   t.end()

--- a/test/validator.js
+++ b/test/validator.js
@@ -171,6 +171,53 @@ Date:   Sat Oct 22 10:22:43 2022 +0200
     This reverts commit 01bc8e6fd81314e76c7fb0d09e5310f609e48bee.
 `
 
+const str13 = `commit 287d681575bdd2099b0cc892f6a90b0323033101
+Author: Stephen Belanger <admin@stephenbelanger.com>
+Date:   Wed Jul 24 10:00:04 2024 -0700
+
+    deps: V8: backport 7857eb34db42
+    
+    Original commit message:
+    
+        Reland^2 "Add ContinuationPreservedEmbedderData builtins to extras binding"
+    
+        This reverts commit cb1277e97a0ed32fd893be9f4e927f6e8b6c566c.
+    
+        > Original change's description:
+        > > Add ContinuationPreservedEmbedderData builtins to extras binding
+        > >
+        > > Node.js and Deno wish to use CPED for AsyncLocalStorage and APM, which
+        > > needs a high performance implementation. These builtins allow JavaScript
+        > > to handle CPED performantly.
+        > >
+        > > Change-Id: I7577be80818524baa52791dfce57d442d7c0c933
+        > > Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5638129
+        > > Commit-Queue: snek <snek@chromium.org>
+        > > Reviewed-by: Darius Mercadier <dmercadier@chromium.org>
+        > > Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+        > > Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
+        > > Cr-Commit-Position: refs/heads/main@{#94607}
+        >
+        > Change-Id: Ief390f0b99891c8de83b4c794180440f91cbaf1f
+        > No-Presubmit: true
+        > No-Tree-Checks: true
+        > No-Try: true
+        > Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5649024
+        > Auto-Submit: Shu-yu Guo <syg@chromium.org>
+        > Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+        > Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+        > Cr-Commit-Position: refs/heads/main@{#94608}
+    
+        Change-Id: I4943071ffe192084e83bfe3113cfe9c92ef31465
+        Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5677045
+        Reviewed-by: Darius Mercadier <dmercadier@chromium.org>
+        Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+        Commit-Queue: snek <snek@chromium.org>
+        Cr-Commit-Position: refs/heads/main@{#94866}
+    
+    Refs: v8/v8@7857eb3
+`
+
 test('Validator - misc', (t) => {
   const v = new Validator()
 
@@ -472,14 +519,15 @@ test('Validator - real commits', (t) => {
     const v = new Validator({
       'validate-no-metadata': true
     })
+    tt.plan(2)
     v.lint(str5)
+    v.lint(str13)
     v.on('commit', (data) => {
       const msgs = data.messages
       const filtered = msgs.filter((item) => {
         return item.level === 'fail'
       })
       tt.equal(filtered.length, 0, 'messages.length')
-      tt.end()
     })
   })
 

--- a/test/validator.js
+++ b/test/validator.js
@@ -453,5 +453,35 @@ test('Validator - real commits', (t) => {
     })
   })
 
+  t.test('validate no metadata should report commits for having metadata', (tt) => {
+    const v = new Validator({
+      'validate-no-metadata': true
+    })
+    v.lint(str)
+    v.on('commit', (data) => {
+      const msgs = data.messages
+      const filtered = msgs.filter((item) => {
+        return item.level === 'fail'
+      })
+      tt.equal(filtered.length, 2, 'messages.length')
+      tt.end()
+    })
+  })
+
+  t.test('validate no metadata should not report commits without metadata', (tt) => {
+    const v = new Validator({
+      'validate-no-metadata': true
+    })
+    v.lint(str5)
+    v.on('commit', (data) => {
+      const msgs = data.messages
+      const filtered = msgs.filter((item) => {
+        return item.level === 'fail'
+      })
+      tt.equal(filtered.length, 0, 'messages.length')
+      tt.end()
+    })
+  })
+
   t.end()
 })


### PR DESCRIPTION
Useful to ensure the commit message doesn't include metadata that should be added by automation (PR-URL and reviewers). In particular, we could use that in the commit linter in nodejs/node to report as invalid commits that include a `PR-URL` or `Reviewed-by` trailers so the CQ refuse to land such commit as having those manually entered is error prone.