### PR TITLE
Add Signed-off-by and Assisted-By rules

### DIFF
--- a/lib/rules/assisted-by-is-trailer.js
+++ b/lib/rules/assisted-by-is-trailer.js
@@ -1,0 +1,49 @@
+const id = 'assisted-by-is-trailer'
+
+export default {
+  id,
+  meta: {
+    description: 'enforce that "Assisted-by:" lines are trailers',
+    recommended: true
+  },
+  defaults: {},
+  options: {},
+  validate: (context, rule) => {
+    const parsed = context.toJSON()
+    const lines = parsed.body.map((line, i) => [line, i])
+    const re = /^Assisted-by:/gi
+    const assisted = lines.filter(([line]) => re.test(line))
+    if (assisted.length !== 0) {
+      const firstAssisted = assisted[0]
+      const emptyLines = lines.filter(([text]) => text.trim().length === 0)
+      // There must be at least one empty line, and the last empty line must be
+      // above the first Assisted-by line.
+      const isTrailer = (emptyLines.length !== 0) &&
+                        emptyLines.at(-1)[1] < firstAssisted[1]
+      if (isTrailer) {
+        context.report({
+          id,
+          message: 'Assisted-by is a trailer',
+          string: '',
+          level: 'pass'
+        })
+      } else {
+        context.report({
+          id,
+          message: 'Assisted-by must be a trailer',
+          string: firstAssisted[0],
+          line: firstAssisted[1],
+          column: 0,
+          level: 'fail'
+        })
+      }
+    } else {
+      context.report({
+        id,
+        message: 'no Assisted-by metadata',
+        string: '',
+        level: 'pass'
+      })
+    }
+  }
+}

--- a/lib/rules/signed-off-by.js
+++ b/lib/rules/signed-off-by.js
@@ -1,0 +1,217 @@
+const id = 'signed-off-by'
+
+// Matches the name and email from a Signed-off-by line
+const signoffParts = /^Signed-off-by: (.*) <([^>]+)>/i
+
+// Bot/AI patterns: name ending in [bot], or GitHub bot noreply emails
+// This is an imperfect heuristic, but there's no standard way to identify
+// bot commits in a reliable, generic way.
+const botNamePattern = /\[bot\]$/i
+const botEmailPattern = /(?:\[bot\]@users\.noreply\.github\.com|github-bot@iojs\.org)$/i
+
+// Matches "Name <email>" author strings
+const authorPattern = /^(.*?)\s*<([^>]+)>/
+const signoffPattern = /^Signed-off-by: /i
+const validSignoff = /^Signed-off-by: .+ <[^@]+@[^@]+\.[^@]+>/i
+const backportPattern = /^Backport-PR-URL:/i
+
+// Parse name and email from an author string like "Name <email>"
+function parseAuthor (authorStr) {
+  if (!authorStr) return null
+  const match = authorStr.match(authorPattern)
+  if (!match) return null // Purely defensive check here
+  return { name: match[1].trim(), email: match[2].toLowerCase() }
+}
+
+// Check if an author string looks like a bot
+function isBotAuthor (authorStr) {
+  const author = parseAuthor(authorStr)
+  if (!author) return false
+  return botNamePattern.test(author.name) || botEmailPattern.test(author.email)
+}
+
+export default {
+  id,
+  meta: {
+    description: 'enforce DCO sign-off',
+    recommended: true
+  },
+  defaults: {},
+  options: {},
+  validate: (context, rule) => {
+    const parsed = context.toJSON()
+
+    // Release commits generally won't have sign-offs
+    if (parsed.release) {
+      context.report({
+        id,
+        message: 'skipping sign-off for release commit',
+        string: '',
+        level: 'skip'
+      })
+      return
+    }
+
+    // Deps commits are cherry-picks/backports/updates from upstream projects
+    // (V8, etc.) and are not expected to have a Signed-off-by. When deps
+    // is mixed with other subsystems, a sign-off might be required but we'll
+    // downgrade to a warn instead of fail in this case.
+    const hasDeps = parsed.subsystems.includes('deps')
+    if (hasDeps && parsed.subsystems.every((s) => s === 'deps')) {
+      context.report({
+        id,
+        message: 'skipping sign-off for deps commit',
+        string: '',
+        level: 'skip'
+      })
+      return
+    }
+
+    // Backport commits (identified by a Backport-PR-URL trailer) are
+    // cherry-picks of existing commits into release branches. The
+    // original commit was already validated.
+    if (parsed.body.some((line) => backportPattern.test(line))) {
+      context.report({
+        id,
+        message: 'skipping sign-off for backport commit',
+        string: '',
+        level: 'skip'
+      })
+      return
+    }
+
+    const signoffs = parsed.body
+      .map((line, i) => [line, i])
+      .filter(([line]) => signoffPattern.test(line))
+
+    // Bot-authored commits don't need a sign-off.
+    // If they have one, warn; otherwise pass.
+    if (isBotAuthor(parsed.author)) {
+      if (signoffs.length === 0) {
+        context.report({
+          id,
+          message: 'skipping sign-off for bot commit',
+          string: '',
+          level: 'pass'
+        })
+      } else {
+        for (const [line, lineNum] of signoffs) {
+          context.report({
+            id,
+            message: 'bot commit should not have a "Signed-off-by" trailer',
+            string: line,
+            line: lineNum,
+            column: 0,
+            level: 'warn'
+          })
+        }
+      }
+      return
+    }
+
+    // Assume it's not a bot commit... a Signed-off-by trailer is required.
+    // For mixed deps commits (deps + other subsystems), downgrade to warn
+    // since the deps portion may legitimately lack a sign-off.
+    if (signoffs.length === 0) {
+      context.report({
+        id,
+        message: hasDeps
+          ? 'Commit with non-deps changes should have a "Signed-off-by" trailer'
+          : 'Commit must have a "Signed-off-by" trailer',
+        string: '',
+        level: hasDeps ? 'warn' : 'fail'
+      })
+      return
+    }
+
+    // Flag every sign-off that has an invalid email format.
+    // Collect valid sign-offs for further checks.
+    const valid = []
+    for (const [line, lineNum] of signoffs) {
+      if (validSignoff.test(line)) {
+        valid.push([line, lineNum])
+      } else {
+        context.report({
+          id,
+          message: '"Signed-off-by" trailer has invalid email',
+          string: line,
+          line: lineNum,
+          column: 0,
+          level: 'fail'
+        })
+      }
+    }
+
+    if (valid.length === 0) {
+      // All sign-offs had invalid emails; already reported above.
+      return
+    }
+
+    // Flag any sign-off that appears to be from a bot or AI agent.
+    // Bots and AI agents are not permitted to sign off on commits.
+    // Collect non-bot sign-offs for further checks. If the commit
+    // itself appears to be from a bot, the case is handled above.
+    const human = []
+    for (const [line, lineNum] of valid) {
+      const { 1: name, 2: email } = line.match(signoffParts)
+      if (botNamePattern.test(name) || botEmailPattern.test(email)) {
+        context.report({
+          id,
+          message: '"Signed-off-by" must be from a human author, ' +
+                   'not a bot or AI agent',
+          string: line,
+          line: lineNum,
+          column: 0,
+          level: 'warn'
+        })
+      } else {
+        human.push([line, lineNum])
+      }
+    }
+
+    // All sign-offs appear to be from bots; already reported above.
+    // If there are no human sign-offs, fail (or warn for mixed deps).
+    if (human.length === 0) {
+      context.report({
+        id,
+        message: hasDeps
+          ? 'Commit with non-deps changes should have a "Signed-off-by" ' +
+            'trailer from a human author'
+          : 'Commit must have a "Signed-off-by" trailer from a human author',
+        string: '',
+        level: hasDeps ? 'warn' : 'fail'
+      })
+      return
+    }
+
+    // When author info is available, warn if none of the human sign-off
+    // emails match the commit author email. This may indicate an automated
+    // tool signed off on behalf of the author.
+    const authorEmail = parseAuthor(parsed.author)?.email
+    if (authorEmail) {
+      const authorMatch = human.some(([line]) => {
+        const { 2: email } = line.match(signoffParts)
+        return email.toLowerCase() === authorEmail
+      })
+      if (!authorMatch) {
+        context.report({
+          id,
+          message: '"Signed-off-by" email does not match the ' +
+                   'commit author email',
+          string: human[0][0],
+          line: human[0][1],
+          column: 0,
+          level: 'warn'
+        })
+        return
+      }
+    }
+
+    context.report({
+      id,
+      message: 'has valid Signed-off-by',
+      string: '',
+      level: 'pass'
+    })
+  }
+}

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -11,6 +11,7 @@ import metadataEnd from './rules/metadata-end.js'
 import prUrl from './rules/pr-url.js'
 import reviewers from './rules/reviewers.js'
 import subsystem from './rules/subsystem.js'
+import signedOffBy from './rules/signed-off-by.js'
 import titleFormat from './rules/title-format.js'
 import titleLength from './rules/title-length.js'
 
@@ -22,6 +23,7 @@ const RULES = {
   'metadata-end': metadataEnd,
   'pr-url': prUrl,
   reviewers,
+  'signed-off-by': signedOffBy,
   subsystem,
   'title-format': titleFormat,
   'title-length': titleLength

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -3,6 +3,7 @@ import Parser from 'gitlint-parser-node'
 import BaseRule from './rule.js'
 
 // Rules
+import assistedByIsTrailer from './rules/assisted-by-is-trailer.js'
 import coAuthoredByIsTrailer from './rules/co-authored-by-is-trailer.js'
 import fixesUrl from './rules/fixes-url.js'
 import lineAfterTitle from './rules/line-after-title.js'
@@ -16,6 +17,7 @@ import titleFormat from './rules/title-format.js'
 import titleLength from './rules/title-length.js'
 
 const RULES = {
+  'assisted-by-is-trailer': assistedByIsTrailer,
   'co-authored-by-is-trailer': coAuthoredByIsTrailer,
   'fixes-url': fixesUrl,
   'line-after-title': lineAfterTitle,

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -155,7 +155,7 @@ test('Test cli flags', (t) => {
   t.test('test stdin with valid JSON', (tt) => {
     const validCommit = {
       id: '2b98d02b52',
-      message: 'stream: make null an invalid chunk to write in object mode\n\nthis harmonizes behavior between readable, writable, and transform\nstreams so that they all handle nulls in object mode the same way by\nconsidering them invalid chunks.\n\nPR-URL: https://github.com/nodejs/node/pull/6170\nReviewed-By: James M Snell <jasnell@gmail.com>\nReviewed-By: Matteo Collina <matteo.collina@gmail.com>'
+      message: 'stream: make null an invalid chunk to write in object mode\n\nthis harmonizes behavior between readable, writable, and transform\nstreams so that they all handle nulls in object mode the same way by\nconsidering them invalid chunks.\n\nSigned-off-by: Calvin Metcalf <cmetcalf@appgeo.com>\nPR-URL: https://github.com/nodejs/node/pull/6170\nReviewed-By: James M Snell <jasnell@gmail.com>\nReviewed-By: Matteo Collina <matteo.collina@gmail.com>'
     }
     const input = JSON.stringify([validCommit])
 
@@ -211,11 +211,11 @@ test('Test cli flags', (t) => {
     const commits = [
       {
         id: 'commit1',
-        message: 'doc: update README\n\nPR-URL: https://github.com/nodejs/node/pull/1111\nReviewed-By: Someone <someone@example.com>'
+        message: 'doc: update README\n\nSigned-off-by: Someone <someone@example.com>\nPR-URL: https://github.com/nodejs/node/pull/1111\nReviewed-By: Someone <someone@example.com>'
       },
       {
         id: 'commit2',
-        message: 'test: add new test case\n\nPR-URL: https://github.com/nodejs/node/pull/2222\nReviewed-By: Someone <someone@example.com>'
+        message: 'test: add new test case\n\nSigned-off-by: Someone <someone@example.com>\nPR-URL: https://github.com/nodejs/node/pull/2222\nReviewed-By: Someone <someone@example.com>'
       }
     ]
     const input = JSON.stringify(commits)
@@ -337,7 +337,7 @@ test('Test cli flags', (t) => {
   t.test('test stdin with --no-validate-metadata', (tt) => {
     const commit = {
       id: 'novalidate',
-      message: 'doc: update README\n\nThis commit has no PR-URL or reviewers'
+      message: 'doc: update README\n\nThis commit has no PR-URL or reviewers\n\nSigned-off-by: Someone <someone@example.com>'
     }
     const input = JSON.stringify([commit])
 

--- a/test/fixtures/commit.json
+++ b/test/fixtures/commit.json
@@ -16,7 +16,7 @@
     "sha": "d3f20ccfaa7b0919a7c5a472e344b7de8829b30c",
     "url": "https://api.github.com/repos/nodejs/node/git/trees/d3f20ccfaa7b0919a7c5a472e344b7de8829b30c"
   },
-  "message": "stream: make null an invalid chunk to write in object mode\n\nthis harmonizes behavior between readable, writable, and transform\nstreams so that they all handle nulls in object mode the same way by\nconsidering them invalid chunks.\n\nPR-URL: https://github.com/nodejs/node/pull/6170\nReviewed-By: James M Snell <jasnell@gmail.com>\nReviewed-By: Matteo Collina <matteo.collina@gmail.com>",
+  "message": "stream: make null an invalid chunk to write in object mode\n\nthis harmonizes behavior between readable, writable, and transform\nstreams so that they all handle nulls in object mode the same way by\nconsidering them invalid chunks.\n\nSigned-off-by: Calvin Metcalf <cmetcalf@appgeo.com>\nPR-URL: https://github.com/nodejs/node/pull/6170\nReviewed-By: James M Snell <jasnell@gmail.com>\nReviewed-By: Matteo Collina <matteo.collina@gmail.com>",
   "parents": [
     {
       "sha": "ec2822adaad76b126b5cccdeaa1addf2376c9aa6",

--- a/test/fixtures/pr.json
+++ b/test/fixtures/pr.json
@@ -12,7 +12,7 @@
         "email": "cmetcalf@appgeo.com",
         "date": "2016-04-13T16:33:55Z"
       },
-      "message": "stream: make null an invalid chunk to write in object mode\n\nthis harmonizes behavior between readable, writable, and transform\nstreams so that they all handle nulls in object mode the same way by\nconsidering them invalid chunks.\n\nPR-URL: https://github.com/nodejs/node/pull/6170\nReviewed-By: James M Snell <jasnell@gmail.com>\nReviewed-By: Matteo Collina <matteo.collina@gmail.com>",
+      "message": "stream: make null an invalid chunk to write in object mode\n\nthis harmonizes behavior between readable, writable, and transform\nstreams so that they all handle nulls in object mode the same way by\nconsidering them invalid chunks.\n\nSigned-off-by: Calvin Metcalf <cmetcalf@appgeo.com>\nPR-URL: https://github.com/nodejs/node/pull/6170\nReviewed-By: James M Snell <jasnell@gmail.com>\nReviewed-By: Matteo Collina <matteo.collina@gmail.com>",
       "tree": {
         "sha": "e4f9381fdd77d1fd38fe27a80dc43486ac732d48",
         "url": "https://api.github.com/repos/nodejs/node/git/trees/e4f9381fdd77d1fd38fe27a80dc43486ac732d48"

--- a/test/rules/assisted-by-is-trailer.js
+++ b/test/rules/assisted-by-is-trailer.js
@@ -1,0 +1,190 @@
+import { test } from 'tap'
+import Rule from '../../lib/rules/assisted-by-is-trailer.js'
+import Commit from 'gitlint-parser-node'
+import Validator from '../../index.js'
+
+test('rule: assisted-by-is-trailer', (t) => {
+  t.test('no assisted-by', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'fhqwhgads'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'assisted-by-is-trailer', 'id')
+      tt.equal(opts.message, 'no Assisted-by metadata', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('no empty lines above', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               'Assisted-by: Whatever'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'assisted-by-is-trailer', 'id')
+      tt.equal(opts.message,
+        'Assisted-by must be a trailer', 'message')
+      tt.equal(opts.string,
+        'Assisted-by: Whatever', 'string')
+      tt.equal(opts.line, 0, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('not trailer - in body before metadata', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Assisted-by: Whatever\n' +
+               '\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'assisted-by-is-trailer', 'id')
+      tt.equal(opts.message,
+        'Assisted-by must be a trailer', 'message')
+      tt.equal(opts.string,
+        'Assisted-by: Whatever', 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('is trailer', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Assisted-by: Whatever\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'assisted-by-is-trailer', 'id')
+      tt.equal(opts.message,
+        'Assisted-by is a trailer', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('multiple assisted-by as trailers', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Assisted-by: Whatever\n' +
+               'Assisted-by: Something else\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'assisted-by-is-trailer', 'id')
+      tt.equal(opts.message,
+        'Assisted-by is a trailer', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('not all are trailers', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Assisted-by: Whatever\n' +
+               '\n' +
+               'Assisted-by: Something else\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'assisted-by-is-trailer', 'id')
+      tt.equal(opts.message,
+        'Assisted-by must be a trailer', 'message')
+      tt.equal(opts.string,
+        'Assisted-by: Whatever', 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.end()
+})

--- a/test/rules/signed-off-by.js
+++ b/test/rules/signed-off-by.js
@@ -1,0 +1,819 @@
+import { test } from 'tap'
+import Rule from '../../lib/rules/signed-off-by.js'
+import Commit from 'gitlint-parser-node'
+import Validator from '../../index.js'
+
+test('rule: signed-off-by', (t) => {
+  t.test('valid sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Foo <foo@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message, 'has valid Signed-off-by', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('missing sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'Commit must have a "Signed-off-by" trailer', 'message')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('invalid email - no angle brackets', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Foo foo@example.com\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        '"Signed-off-by" trailer has invalid email', 'message')
+      tt.equal(opts.string,
+        'Signed-off-by: Foo foo@example.com', 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('invalid email - no domain', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Foo <foo@>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        '"Signed-off-by" trailer has invalid email', 'message')
+      tt.equal(opts.string,
+        'Signed-off-by: Foo <foo@>', 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('missing name', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: <foo@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        '"Signed-off-by" trailer has invalid email', 'message')
+      tt.equal(opts.string,
+        'Signed-off-by: <foo@example.com>', 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('release commit', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: '2024-01-01, Version 22.0.0 (Current)\n' +
+               '\n' +
+               'Notable changes:\n' +
+               '\n' +
+               'Some changes here.'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'skipping sign-off for release commit', 'message')
+      tt.equal(opts.level, 'skip', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('deps commit without sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Richard Lau',
+        email: 'richard.lau@ibm.com',
+        date: '2026-03-28T22:57:44Z'
+      },
+      message: 'deps: V8: cherry-pick cf1bce40a5ef\n' +
+               '\n' +
+               'Original commit message:\n' +
+               '\n' +
+               '    [wasm] Fix S128Const on big endian\n' +
+               '\n' +
+               'Refs: https://github.com/v8/v8/commit/cf1bce40a5ef\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/62449\n' +
+               'Reviewed-By: Guy Bedford <guybedford@gmail.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'skipping sign-off for deps commit', 'message')
+      tt.equal(opts.level, 'skip', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('deps commit with sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Richard Lau',
+        email: 'richard.lau@ibm.com',
+        date: '2026-03-28T22:57:44Z'
+      },
+      message: 'deps: V8: cherry-pick cf1bce40a5ef\n' +
+               '\n' +
+               'Original commit message:\n' +
+               '\n' +
+               '    [wasm] Fix S128Const on big endian\n' +
+               '\n' +
+               'Signed-off-by: Richard Lau <richard.lau@ibm.com>\n' +
+               'Refs: https://github.com/v8/v8/commit/cf1bce40a5ef\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/62449\n' +
+               'Reviewed-By: Guy Bedford <guybedford@gmail.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'skipping sign-off for deps commit', 'message')
+      tt.equal(opts.level, 'skip', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('mixed deps commit without sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2026-03-28T22:57:44Z'
+      },
+      message: 'deps,src: update V8 and fix build\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'Commit with non-deps changes should have a ' +
+        '"Signed-off-by" trailer', 'message')
+      tt.equal(opts.level, 'warn', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('mixed deps commit with valid sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2026-03-28T22:57:44Z'
+      },
+      message: 'deps,src: update V8 and fix build\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Foo <foo@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message, 'has valid Signed-off-by', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('backport commit without sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Anna Henningsen',
+        email: 'anna@addaleax.net',
+        date: '2026-03-03T23:12:18Z'
+      },
+      message: 'src: convert context_frame field in AsyncWrap\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/62103\n' +
+               'Backport-PR-URL: https://github.com/nodejs/node/pull/62357\n' +
+               'Reviewed-By: Anna Henningsen <anna@addaleax.net>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'skipping sign-off for backport commit', 'message')
+      tt.equal(opts.level, 'skip', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('backport commit with sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Anna Henningsen',
+        email: 'anna@addaleax.net',
+        date: '2026-03-03T23:12:18Z'
+      },
+      message: 'src: convert context_frame field in AsyncWrap\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Anna Henningsen <anna@addaleax.net>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/62103\n' +
+               'Backport-PR-URL: https://github.com/nodejs/node/pull/62357\n' +
+               'Reviewed-By: Anna Henningsen <anna@addaleax.net>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'skipping sign-off for backport commit', 'message')
+      tt.equal(opts.level, 'skip', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('multiple valid sign-offs', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Foo <foo@example.com>\n' +
+               'Signed-off-by: Bar <bar@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Baz <baz@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message, 'has valid Signed-off-by', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('bot author with sign-off - name with [bot] suffix', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'dependabot[bot]',
+        email: '49699333+dependabot[bot]@users.noreply.github.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: dependabot[bot] ' +
+               '<49699333+dependabot[bot]@users.noreply.github.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'bot commit should not have a "Signed-off-by" trailer', 'message')
+      tt.match(opts.string, /dependabot\[bot\]/, 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'warn', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('bot author with sign-off - GitHub bot noreply email', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'some-tool[bot]',
+        email: 'some-tool[bot]@users.noreply.github.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: some-tool[bot] ' +
+               '<some-tool[bot]@users.noreply.github.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'bot commit should not have a "Signed-off-by" trailer', 'message')
+      tt.match(opts.string, /some-tool\[bot\]/, 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'warn', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('bot author without sign-off', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'dependabot[bot]',
+        email: '49699333+dependabot[bot]@users.noreply.github.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'build(deps): bump some-package from 1.0.0 to 2.0.0\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'skipping sign-off for bot commit', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('bot author - Node.js GitHub Bot', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Node.js GitHub Bot',
+        email: 'github-bot@iojs.org',
+        date: '2026-03-22T00:28:21Z'
+      },
+      message: 'test: update WPT for url to fc3e651593\n' +
+               '\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'skipping sign-off for bot commit', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('bot author with human sign-off', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'dependabot[bot]',
+        email: '49699333+dependabot[bot]@users.noreply.github.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'build(deps): bump some-package from 1.0.0 to 2.0.0\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Human <human@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        'bot commit should not have a "Signed-off-by" trailer', 'message')
+      tt.equal(opts.string,
+        'Signed-off-by: Human <human@example.com>', 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'warn', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('author email mismatch', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Alice',
+        email: 'alice@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Bob <bob@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message,
+        '"Signed-off-by" email does not match the ' +
+        'commit author email', 'message')
+      tt.equal(opts.string,
+        'Signed-off-by: Bob <bob@example.com>', 'string')
+      tt.equal(opts.line, 3, 'line')
+      tt.equal(opts.column, 0, 'column')
+      tt.equal(opts.level, 'warn', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('author email matches one of multiple sign-offs', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Alice',
+        email: 'alice@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Bob <bob@example.com>\n' +
+               'Signed-off-by: Alice <alice@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message, 'has valid Signed-off-by', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('no author info available - skips mismatch check', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    // Simulate stdin JSON input which has no author info.
+    // Use a plain object context with no author field.
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Someone <someone@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message, 'has valid Signed-off-by', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('author email mismatch is case-insensitive', (tt) => {
+    tt.plan(4)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'Foo@Example.COM',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Foo <foo@example.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'signed-off-by', 'id')
+      tt.equal(opts.message, 'has valid Signed-off-by', 'message')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+
+    Rule.validate(context)
+  })
+
+  t.test('multiple sign-offs with some invalid emails', (tt) => {
+    tt.plan(9)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Bad One bad@\n' +
+               'Signed-off-by: Foo <foo@example.com>\n' +
+               'Signed-off-by: Bad Two noangles@example.com\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    const reports = []
+    context.report = (opts) => {
+      reports.push(opts)
+    }
+
+    Rule.validate(context)
+
+    // Should get 3 reports: 2 fails for invalid emails + 1 pass
+    tt.equal(reports.length, 3, 'total reports')
+
+    tt.equal(reports[0].level, 'fail', 'first invalid is fail')
+    tt.equal(reports[0].message,
+      '"Signed-off-by" trailer has invalid email', 'first message')
+    tt.equal(reports[0].string,
+      'Signed-off-by: Bad One bad@', 'first string')
+
+    tt.equal(reports[1].level, 'fail', 'second invalid is fail')
+    tt.equal(reports[1].message,
+      '"Signed-off-by" trailer has invalid email', 'second message')
+    tt.equal(reports[1].string,
+      'Signed-off-by: Bad Two noangles@example.com', 'second string')
+
+    tt.equal(reports[2].level, 'pass', 'valid one passes')
+    tt.equal(reports[2].message,
+      'has valid Signed-off-by', 'pass message')
+  })
+
+  t.test('human author with only bot sign-offs', (tt) => {
+    tt.plan(5)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Alice',
+        email: 'alice@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: dependabot[bot] ' +
+               '<49699333+dependabot[bot]@users.noreply.github.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    const reports = []
+    context.report = (opts) => {
+      reports.push(opts)
+    }
+
+    Rule.validate(context)
+
+    // Should get 2 reports: warn for bot sign-off + fail for no human sign-off
+    tt.equal(reports.length, 2, 'total reports')
+
+    tt.equal(reports[0].level, 'warn', 'bot sign-off is warn')
+    tt.match(reports[0].string, /dependabot\[bot\]/, 'bot string')
+
+    tt.equal(reports[1].level, 'fail', 'no human sign-off is fail')
+    tt.equal(reports[1].message,
+      'Commit must have a "Signed-off-by" trailer from a human author',
+      'fail message')
+  })
+
+  t.test('multiple sign-offs with human and bot', (tt) => {
+    tt.plan(7)
+    const v = new Validator()
+    const context = new Commit({
+      sha: 'e7c077c610afa371430180fbd447bfef60ebc5ea',
+      author: {
+        name: 'Foo',
+        email: 'foo@example.com',
+        date: '2016-04-12T19:42:23Z'
+      },
+      message: 'test: fix something\n' +
+               '\n' +
+               'Some description.\n' +
+               '\n' +
+               'Signed-off-by: Foo <foo@example.com>\n' +
+               'Signed-off-by: dependabot[bot] <support@github.com>\n' +
+               'PR-URL: https://github.com/nodejs/node/pull/1234\n' +
+               'Reviewed-By: Bar <bar@example.com>'
+    }, v)
+
+    const reports = []
+    context.report = (opts) => {
+      reports.push(opts)
+    }
+
+    Rule.validate(context)
+
+    // Should get 2 reports: warn for bot + pass for human
+    tt.equal(reports.length, 2, 'total reports')
+
+    tt.equal(reports[0].level, 'warn', 'bot is warn')
+    tt.equal(reports[0].message,
+      '"Signed-off-by" must be from a human author, ' +
+      'not a bot or AI agent', 'bot message')
+    tt.match(reports[0].string,
+      /dependabot\[bot\]/, 'bot string')
+
+    tt.equal(reports[1].level, 'pass', 'human passes')
+    tt.equal(reports[1].message,
+      'has valid Signed-off-by', 'pass message')
+    tt.equal(reports[1].string, '', 'pass string')
+  })
+
+  t.end()
+})

--- a/test/validator.js
+++ b/test/validator.js
@@ -15,6 +15,7 @@ CommitDate: Wed Apr 20 13:28:35 2016 -0700
     streams so that they all handle nulls in object mode the same way by
     considering them invalid chunks.
 
+    Signed-off-by: Calvin Metcalf <cmetcalf@appgeo.com>
     PR-URL: https://github.com/nodejs/node/pull/6170
     Reviewed-By: James M Snell <jasnell@gmail.com>
     Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
@@ -31,6 +32,7 @@ Date:   Tue Mar 29 08:09:37 2016 -0500
     The offending commit broke certain usages of piping from stdin.
 
     Fixes: https://github.com/nodejs/node/issues/5927
+    Signed-off-by: Evan Lucas <evanlucas@me.com>
     PR-URL: https://github.com/nodejs/node/pull/5947
     Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
     Reviewed-By: Alexis Campailla <orangemocha@nodejs.org>
@@ -50,6 +52,7 @@ Date:   Fri Apr 15 13:32:36 2016 +0200
     [1] https://github.com/nodejs/node/pull/5172/commits/ae18bbef48d87d9c641df85369f62cfd5ed8c250
 
     Fixes: https://github.com/nodejs/node/issues/6214
+    Signed-off-by: Michaël Zasso <targos@protonmail.com>
     PR-URL: https://github.com/nodejs/node/pull/6215
     Reviewed-By: James M Snell <jasnell@gmail.com>
     Reviewed-By: Brian White <mscdex@mscdex.net>`
@@ -63,6 +66,7 @@ Date:   Thu Mar 3 10:10:46 2016 -0600
     The properties on memoryUsage were not checked before,
     this commit checks them.
 
+    Signed-off-by: Wyatt Preul <wpreul@gmail.com>
     PR-URL: #5546
     Reviewed-By: Colin Ihrig <cjihrig@gmail.com>`
 
@@ -73,7 +77,9 @@ Date:   Thu Mar 3 10:10:46 2016 -0600
     test: check memoryUsage properties
 
     The properties on memoryUsage were not checked before,
-    this commit checks them.`
+    this commit checks them.
+
+    Signed-off-by: Wyatt Preul <wpreul@gmail.com>`
 
 /* eslint-disable */
 const str6 = {
@@ -94,7 +100,7 @@ const str6 = {
     "sha": "b505c0ffa0555730e9f4cdb391d1ebeb48bb2f59",
     "url": "https://api.github.com/repos/nodejs/node/git/trees/b505c0ffa0555730e9f4cdb391d1ebeb48bb2f59"
   },
-  "message": "fs: fix handling of `uv_stat_t` fields\n\n`FChown` and `Chown` test that the `uid` and `gid` parameters\nthey receive are unsigned integers, but `Stat()` and `FStat()`\nwould return the corresponding fields of `uv_stat_t` as signed\nintegers. Applications which pass those these values directly\nto `Chown` may fail\n(e.g. for `nobody` on OS X, who has an `uid` of `-2`, see e.g.\nhttps://github.com/nodejs/node-v0.x-archive/issues/5890).\n\nThis patch changes the `Integer::New()` call for `uid` and `gid`\nto `Integer::NewFromUnsigned()`.\n\nAll other fields are kept as they are, for performance, but\nstrictly speaking the respective sizes of those\nfields aren’t specified, either.\n\nRef: https://github.com/npm/npm/issues/13918\nPR-URL: https://github.com/nodejs/node/pull/8515\nReviewed-By: Ben Noordhuis <info@bnoordhuis.nl>\nReviewed-By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>\nReviewed-By: James M Snell <jasnell@gmail.com>\n\nundo accidental change to other fields of uv_fs_stat",
+  "message": "fs: fix handling of `uv_stat_t` fields\n\n`FChown` and `Chown` test that the `uid` and `gid` parameters\nthey receive are unsigned integers, but `Stat()` and `FStat()`\nwould return the corresponding fields of `uv_stat_t` as signed\nintegers. Applications which pass those these values directly\nto `Chown` may fail\n(e.g. for `nobody` on OS X, who has an `uid` of `-2`, see e.g.\nhttps://github.com/nodejs/node-v0.x-archive/issues/5890).\n\nThis patch changes the `Integer::New()` call for `uid` and `gid`\nto `Integer::NewFromUnsigned()`.\n\nAll other fields are kept as they are, for performance, but\nstrictly speaking the respective sizes of those\nfields aren’t specified, either.\n\nSigned-off-by: Anna Henningsen <anna@addaleax.net>\nRef: https://github.com/npm/npm/issues/13918\nPR-URL: https://github.com/nodejs/node/pull/8515\nReviewed-By: Ben Noordhuis <info@bnoordhuis.nl>\nReviewed-By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>\nReviewed-By: James M Snell <jasnell@gmail.com>\n\nundo accidental change to other fields of uv_fs_stat",
   "parents": [
     {
       "sha": "4e76bffc0c7076a5901179e70c7b8a8f9fcd22e4",
@@ -110,6 +116,8 @@ Author: Wyatt Preul <wpreul@gmail.com>
 Date:   Thu Mar 3 10:10:46 2016 -0600
 
     test: check memoryUsage properties.
+
+    Signed-off-by: Wyatt Preul <wpreul@gmail.com>
 `
 
 const str8 = `commit 7d3a7ea0d7df9b6f11df723dec370f49f4f87e99
@@ -117,6 +125,8 @@ Author: Wyatt Preul <wpreul@gmail.com>
 Date:   Thu Mar 3 10:10:46 2016 -0600
 
     test: Check memoryUsage properties
+
+    Signed-off-by: Wyatt Preul <wpreul@gmail.com>
 `
 
 const str9 = `commit 7d3a7ea0d7df9b6f11df723dec370f49f4f87e99
@@ -124,6 +134,8 @@ Author: Wyatt Preul <wpreul@gmail.com>
 Date:   Thu Mar 3 10:10:46 2016 -0600
 
     test: Check memoryUsage properties.
+
+    Signed-off-by: Wyatt Preul <wpreul@gmail.com>
 `
 
 const str10 = `commit b04fe688d5859f707cf1a5e0206967268118bf7a
@@ -169,6 +181,8 @@ Date:   Sat Oct 22 10:22:43 2022 +0200
     Revert "deps: V8: forward declaration of \`Rtl*FunctionTable\`"
 
     This reverts commit 01bc8e6fd81314e76c7fb0d09e5310f609e48bee.
+
+    Signed-off-by: Michaël Zasso <targos@protonmail.com>
 `
 
 test('Validator - misc', (t) => {
@@ -395,7 +409,7 @@ test('Validator - real commits', (t) => {
       const item = filtered[0]
       tt.equal(item.id, 'metadata-end', 'id')
       tt.equal(item.message, 'commit metadata at end of message', 'message')
-      tt.equal(item.line, 22, 'line')
+      tt.equal(item.line, 23, 'line')
       tt.equal(item.column, 0, 'column')
       tt.end()
     })


### PR DESCRIPTION
Add validation rules for `Signed-off-by` and `Assisted-by` footers.

BEGIN_COMMIT_OVERRIDE
feat: add Signed-off-by and Assisted-By rules
END_COMMIT_OVERRIDE