### PR TITLE
feat!: parse trailers using `git` if available, allow longer lines

### DIFF
--- a/lib/gitlint-parser.js
+++ b/lib/gitlint-parser.js
@@ -37,12 +37,12 @@ export default class Parser extends Base {
       'interpret-trailers', '--only-trailers', '--only-input', '--no-divider'
     ], {
       encoding: 'utf-8',
-      input: `${commitMessage}\n`
+      input: `'dummy subject\n\n${commitMessage.join('\n')}\n`
     }).stdout
 
     let originalTrailers
     try {
-      originalTrailers = interpretTrailers(body.join('\n')).trim()
+      originalTrailers = interpretTrailers(body).trim()
     } catch (err) {
       console.warn('git is not available, trailers detection might be a bit ' +
                    'off which is acceptable in most cases', err)
@@ -50,14 +50,14 @@ export default class Parser extends Base {
     }
     const trailerFreeBody = body.slice(1) // clone, and remove the first empty line
     const stillInTrailers = () => {
-      const result = interpretTrailers(trailerFreeBody.join('\n'))
+      const result = interpretTrailers(trailerFreeBody)
       return result.length && originalTrailers.startsWith(result.trim())
     }
     for (let i = trailerFreeBody.length - 1; stillInTrailers(); i--) {
       // Remove last line until git no longer detects any trailers
       trailerFreeBody.pop()
     }
-    this._metaStart = trailerFreeBody.length + 1
+    this._metaStart = trailerFreeBody.length + 1 // the subject line needs to be counted
     for (let i = trailerFreeBody.length - 1; trailerFreeBody[i] === ''; i--) {
       // Remove additional empty line(s)
       trailerFreeBody.pop()

--- a/lib/gitlint-parser.js
+++ b/lib/gitlint-parser.js
@@ -1,0 +1,171 @@
+import { spawnSync } from 'node:child_process'
+import Base from 'gitlint-parser-base'
+
+const revertRE = /Revert "(.*)"$/
+const workingRE = /Working on v([\d]+)\.([\d]+).([\d]+)$/
+const releaseRE = /([\d]{4})-([\d]{2})-([\d]{2}),? Version/
+const reviewedByRE = /^Reviewed-By: (.*)$/
+const fixesRE = /^Fixes: (.*)$/
+const prUrlRE = /^PR-URL: (.*)$/
+const refsRE = /^Refs?: (.*)$/
+
+export default class Parser extends Base {
+  constructor (str, validator) {
+    super(str, validator)
+    this.subsystems = []
+    this.fixes = []
+    this.prUrl = null
+    this.refs = []
+    this.reviewers = []
+    this._metaStart = 0
+    this._metaEnd = 0
+    this._parse()
+  }
+
+  _setMetaStart (n) {
+    if (this._metaStart) return
+    this._metaStart = n
+  }
+
+  _setMetaEnd (n) {
+    if (n < this._metaEnd) return
+    this._metaEnd = n
+  }
+
+  _parseTrailers (body) {
+    const interpretTrailers = commitMessage => spawnSync('git', [
+      'interpret-trailers', '--only-trailers', '--only-input', '--no-divider'
+    ], {
+      encoding: 'utf-8',
+      input: `${commitMessage}\n`
+    }).stdout
+
+    let originalTrailers
+    try {
+      originalTrailers = interpretTrailers(body.join('\n')).trim()
+    } catch (err) {
+      console.warn('git is not available, trailers detection might be a bit ' +
+                   'off which is acceptable in most cases', err)
+      return body
+    }
+    const trailerFreeBody = body.slice(1) // clone, and remove the first empty line
+    const stillInTrailers = () => {
+      const result = interpretTrailers(trailerFreeBody.join('\n'))
+      return result.length && originalTrailers.startsWith(result.trim())
+    }
+    for (let i = trailerFreeBody.length - 1; stillInTrailers(); i--) {
+      // Remove last line until git no longer detects any trailers
+      trailerFreeBody.pop()
+    }
+    this._metaStart = trailerFreeBody.length + 1
+    for (let i = trailerFreeBody.length - 1; trailerFreeBody[i] === ''; i--) {
+      // Remove additional empty line(s)
+      trailerFreeBody.pop()
+    }
+    this._metaEnd = body.length - 1
+    this.trailerFreeBody = trailerFreeBody
+    return (this.trailers = originalTrailers.split('\n'))
+  }
+
+  _parse () {
+    const revert = this.isRevert()
+    if (!revert) {
+      this.subsystems = getSubsystems(this.title || '')
+    } else {
+      const matches = this.title.match(revertRE)
+      if (matches) {
+        const title = matches[1]
+        this.subsystems = getSubsystems(title)
+      }
+    }
+
+    const trailers = this._parseTrailers(this.body)
+
+    for (let i = 0; i < trailers.length; i++) {
+      const line = trailers[i]
+      const reviewedBy = reviewedByRE.exec(line)
+      if (reviewedBy) {
+        this._setMetaStart(i)
+        this._setMetaEnd(i)
+        this.reviewers.push(reviewedBy[1])
+        continue
+      }
+
+      const fixes = fixesRE.exec(line)
+      if (fixes) {
+        this._setMetaStart(i)
+        this._setMetaEnd(i)
+        this.fixes.push(fixes[1])
+        continue
+      }
+
+      const prUrl = prUrlRE.exec(line)
+      if (prUrl) {
+        this._setMetaStart(i)
+        this._setMetaEnd(i)
+        this.prUrl = prUrl[1]
+        continue
+      }
+
+      const refs = refsRE.exec(line)
+      if (refs) {
+        this._setMetaStart(i)
+        this._setMetaEnd(i)
+        this.refs.push(refs[1])
+        continue
+      }
+
+      if (this._metaStart && !this._metaEnd) { this._setMetaEnd(i) }
+    }
+  }
+
+  isRevert () {
+    return revertRE.test(this.title)
+  }
+
+  isWorkingCommit () {
+    return workingRE.test(this.title)
+  }
+
+  isReleaseCommit () {
+    return releaseRE.test(this.title)
+  }
+
+  toJSON () {
+    return {
+      sha: this.sha,
+      title: this.title,
+      subsystems: this.subsystems,
+      author: this.author,
+      date: this.date,
+      fixes: this.fixes,
+      refs: this.refs,
+      prUrl: this.prUrl,
+      reviewers: this.reviewers,
+      body: this.body,
+      trailers: this.trailers,
+      trailerFreeBody: this.trailerFreeBody,
+      revert: this.isRevert(),
+      release: this.isReleaseCommit(),
+      working: this.isWorkingCommit(),
+      metadata: {
+        start: this._metaStart,
+        end: this._metaEnd
+      }
+    }
+  }
+}
+
+function getSubsystems (str) {
+  str = str || ''
+  const colon = str.indexOf(':')
+  if (colon === -1) {
+    return []
+  }
+
+  const subStr = str.slice(0, colon)
+  const subs = subStr.split(',')
+  return subs.map((item) => {
+    return item.trim()
+  })
+}

--- a/lib/rules/line-length.js
+++ b/lib/rules/line-length.js
@@ -7,10 +7,12 @@ export default {
     recommended: true
   },
   defaults: {
-    length: 72
+    length: 72,
+    trailerLength: 120
   },
   options: {
-    length: 72
+    length: 72,
+    trailerLength: 120
   },
   validate: (context, rule) => {
     const len = rule.options.length
@@ -27,19 +29,14 @@ export default {
       return
     }
     let failed = false
-    for (let i = 0; i < parsed.body.length; i++) {
-      const line = parsed.body[i]
+    const body = parsed.trailerFreeBody ?? parsed.body
+    for (let i = 0; i < body.length; i++) {
+      const line = body[i]
 
       // Skip quoted lines, e.g. for original commit messages of V8 backports.
       if (line.startsWith('    ')) { continue }
       // Skip lines with URLs.
       if (/https?:\/\//.test(line)) { continue }
-      // Skip co-authorship.
-      if (/^co-authored-by:/i.test(line)) { continue }
-      // Skip DCO sign-offs.
-      if (/^signed-off-by:/i.test(line)) { continue }
-      // Skip agentic assistants.
-      if (/^assisted-by:/i.test(line)) { continue }
 
       if (line.length > len) {
         failed = true
@@ -49,6 +46,22 @@ export default {
           string: line,
           maxLength: len,
           line: i,
+          column: len,
+          level: 'fail'
+        })
+      }
+    }
+    for (let i = 0; i < (parsed.trailers?.length ?? 0); i++) {
+      const line = parsed.trailers[i]
+      const len = rule.options.trailerLength
+      if (line.length > len) {
+        failed = true
+        context.report({
+          id,
+          message: `Trailer should be <= ${len} columns.`,
+          string: line,
+          maxLength: len,
+          line: i + parsed.body.length - parsed.trailers.length,
           column: len,
           level: 'fail'
         })

--- a/lib/rules/line-length.js
+++ b/lib/rules/line-length.js
@@ -45,7 +45,7 @@ export default {
           message: `Line should be <= ${len} columns.`,
           string: line,
           maxLength: len,
-          line: i,
+          line: i + parsed.body.length - body.length,
           column: len,
           level: 'fail'
         })

--- a/lib/rules/signed-off-by.js
+++ b/lib/rules/signed-off-by.js
@@ -67,10 +67,12 @@ export default {
       return
     }
 
+    const body = parsed.trailers ?? parsed.body
+
     // Backport commits (identified by a Backport-PR-URL trailer) are
     // cherry-picks of existing commits into release branches. The
     // original commit was already validated.
-    if (parsed.body.some((line) => backportPattern.test(line))) {
+    if (body.some((line) => backportPattern.test(line))) {
       context.report({
         id,
         message: 'skipping sign-off for backport commit',
@@ -80,9 +82,9 @@ export default {
       return
     }
 
-    const signoffs = parsed.body
-      .map((line, i) => [line, i])
-      .filter(([line]) => signoffPattern.test(line))
+    const signoffs = body
+      .filter(line => signoffPattern.test(line))
+      .map((line, i) => [line, i + parsed.body.length - body.length])
 
     // Bot-authored commits don't need a sign-off.
     // If they have one, warn; otherwise pass.

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,5 +1,5 @@
 import EE from 'node:events'
-import Parser from 'gitlint-parser-node'
+import Parser from './gitlint-parser.js'
 import BaseRule from './rule.js'
 
 // Rules

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
-        "gitlint-parser-node": "^1.1.0"
+        "gitlint-parser-base": "^2.0.0"
       },
       "bin": {
         "core-validate-commit": "bin/cmd.js"
@@ -55,7 +55,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1031,7 +1030,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1222,19 +1220,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
     },
     "node_modules/check-pkg": {
       "version": "2.1.1",
@@ -1918,7 +1903,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2126,7 +2110,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2194,7 +2177,6 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -2221,7 +2203,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2238,7 +2219,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -2407,7 +2387,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2882,15 +2861,6 @@
       "resolved": "https://registry.npmjs.org/gitlint-parser-base/-/gitlint-parser-base-2.0.0.tgz",
       "integrity": "sha512-kWkbGGH55AigPQgTz9ZEomv8uQn2GRZiFgAg+SbTIV+8ineU8f3QDeAQHzS7h9yKVuE7cjcgQm0ENmHPM0bxMQ==",
       "license": "MIT"
-    },
-    "node_modules/gitlint-parser-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gitlint-parser-node/-/gitlint-parser-node-1.1.0.tgz",
-      "integrity": "sha512-h99xAvajhfkTtwVo8q9oBlL8+QrljJltguykpszQWyu0D9SVE5+5CqfEn9qn5IJ254Q2mr1ByjrFu9Rs2niSyA==",
-      "license": "MIT",
-      "dependencies": {
-        "gitlint-parser-base": "^2.0.0"
-      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -6008,7 +5978,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -6465,7 +6434,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6594,7 +6562,6 @@
       ],
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001565",
         "electron-to-chromium": "^1.4.601",
@@ -7365,7 +7332,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-ci": "npm run test && c8 report --reporter=lcov"
   },
   "dependencies": {
-    "gitlint-parser-node": "^1.1.0"
+    "gitlint-parser-base": "^2.0.0"
   },
   "devDependencies": {
     "c8": "^7.13.0",

--- a/test/gitlint-parser.js
+++ b/test/gitlint-parser.js
@@ -1,0 +1,321 @@
+import { test } from 'tap'
+import Parser from '../lib/gitlint-parser.js'
+
+test('Parser', (t) => {
+  t.test('basic commit with PR-URL and reviewers', (tt) => {
+    tt.plan(10)
+    const input = `commit e7c077c610afa371430180fbd447bfef60ebc5ea
+Author: Calvin Metcalf <cmetcalf@appgeo.com>
+Date:   Tue Apr 12 15:42:23 2016 -0400
+
+    stream: make null an invalid chunk to write in object mode
+
+    this harmonizes behavior between readable, writable, and transform
+    streams so that they all handle nulls in object mode the same way by
+    considering them invalid chunks.
+
+    PR-URL: https://github.com/nodejs/node/pull/6170
+    Reviewed-By: James M Snell <jasnell@gmail.com>
+    Reviewed-By: Matteo Collina <matteo.collina@gmail.com>`
+
+    const data = { name: 'biscuits' }
+
+    const v = {
+      report: (obj) => {
+        tt.pass('called report')
+        tt.equal(obj.data, data, 'obj')
+      }
+    }
+    const p = new Parser(input, v)
+    const c = p.toJSON()
+    tt.equal(c.sha, 'e7c077c610afa371430180fbd447bfef60ebc5ea', 'sha')
+    tt.equal(c.author, 'Calvin Metcalf <cmetcalf@appgeo.com>', 'author')
+    tt.equal(c.date, 'Tue Apr 12 15:42:23 2016 -0400', 'date')
+    tt.deepEqual(c.subsystems, ['stream'], 'subsystems')
+    tt.deepEqual(c.fixes, [], 'fixes')
+    tt.equal(c.prUrl, 'https://github.com/nodejs/node/pull/6170', 'prUrl')
+    tt.deepEqual(c.reviewers, [
+      'James M Snell <jasnell@gmail.com>',
+      'Matteo Collina <matteo.collina@gmail.com>'
+    ], 'reviewers')
+    tt.deepEqual(c.metadata, {
+      start: 5,
+      end: 7
+    }, 'metadata')
+    p.report(data)
+  })
+
+  t.test('basic commit using format=fuller', (tt) => {
+    tt.plan(9)
+    const input = `commit e7c077c610afa371430180fbd447bfef60ebc5ea
+Author:     Calvin Metcalf <cmetcalf@appgeo.com>
+AuthorDate: Tue Apr 12 15:42:23 2016 -0400
+Commit:     James M Snell <jasnell@gmail.com>
+CommitDate: Tue Apr 12 15:42:23 2016 -0400
+
+    stream: make null an invalid chunk to write in object mode
+
+    this harmonizes behavior between readable, writable, and transform
+    streams so that they all handle nulls in object mode the same way by
+    considering them invalid chunks.
+
+    PR-URL: https://github.com/nodejs/node/pull/6170
+    Reviewed-By: James M Snell <jasnell@gmail.com>
+    Reviewed-By: Matteo Collina <matteo.collina@gmail.com>`
+
+    const data = { name: 'biscuits' }
+
+    const v = {
+      report: (obj) => {
+        tt.pass('called report')
+        tt.equal(obj.data, data, 'obj')
+      }
+    }
+    const p = new Parser(input, v)
+    const c = p.toJSON()
+    tt.equal(c.sha, 'e7c077c610afa371430180fbd447bfef60ebc5ea', 'sha')
+    tt.equal(c.author, 'Calvin Metcalf <cmetcalf@appgeo.com>', 'author')
+    tt.equal(c.date, 'Tue Apr 12 15:42:23 2016 -0400', 'date')
+    tt.deepEqual(c.subsystems, ['stream'], 'subsystems')
+    tt.deepEqual(c.fixes, [], 'fixes')
+    tt.equal(c.prUrl, 'https://github.com/nodejs/node/pull/6170', 'prUrl')
+    tt.deepEqual(c.reviewers, [
+      'James M Snell <jasnell@gmail.com>',
+      'Matteo Collina <matteo.collina@gmail.com>'
+    ], 'reviewers')
+    p.report(data)
+  })
+
+  t.test('revert commit', (tt) => {
+    tt.plan(13)
+    const input = `commit 1d4c7993a9c6dcacaca5074a80b1043e977c43fb
+Author: Rod Vagg <rod@vagg.org>
+Date:   Wed Jun 8 16:32:10 2016 +1000
+
+    Revert "test: change duration_ms to duration"
+
+    This reverts commit d413378e513c47a952f7979c74f4a4d9f144ca7d.
+
+    PR-URL: https://github.com/nodejs/node/pull/7216
+    Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
+    Reviewed-By: James M Snell <jasnell@gmail.com>
+    Reviewed-By: Michaël Zasso <mic.besace@gmail.com>
+    Reviewed-By: Johan Bergström <bugs@bergstroem.nu>`
+    const data = { name: 'biscuits' }
+
+    const v = {
+      report: (obj) => {
+        tt.pass('called report')
+        tt.equal(obj.data, data, 'obj')
+      }
+    }
+    const p = new Parser(input, v)
+    const c = p.toJSON()
+    tt.equal(c.sha, '1d4c7993a9c6dcacaca5074a80b1043e977c43fb', 'sha')
+    tt.equal(c.author, 'Rod Vagg <rod@vagg.org>', 'author')
+    tt.equal(c.date, 'Wed Jun 8 16:32:10 2016 +1000', 'date')
+    tt.deepEqual(c.subsystems, ['test'], 'subsystems')
+    tt.deepEqual(c.fixes, [], 'fixes')
+    tt.equal(c.prUrl, 'https://github.com/nodejs/node/pull/7216', 'prUrl')
+    tt.deepEqual(c.reviewers, [
+      'Colin Ihrig <cjihrig@gmail.com>',
+      'James M Snell <jasnell@gmail.com>',
+      'Michaël Zasso <mic.besace@gmail.com>',
+      'Johan Bergström <bugs@bergstroem.nu>'
+    ], 'reviewers')
+
+    tt.equal(c.revert, true, 'revert')
+    tt.equal(c.release, false, 'release')
+    tt.equal(c.working, false, 'working')
+    tt.deepEqual(c.metadata, {
+      start: 3,
+      end: 7
+    }, 'metadata')
+    p.report(data)
+  })
+
+  t.test('backport commit', (tt) => {
+    const input = `commit 5cdbbdf94d6f656230293ddd2a71dedf11cab17d
+Author: Ben Noordhuis <info@bnoordhuis.nl>
+Date:   Thu Jul 7 14:29:32 2016 -0700
+
+    deps: cherry-pick 1f53e42 from v8 upstream
+
+    Original commit message:
+
+        Handle symbols in FrameMirror#invocationText().
+
+        Fix a TypeError when putting together the invocationText for a
+        symbol method's stack frame.
+
+        See https://github.com/nodejs/node/issues/7536.
+
+        Review-Url: https://codereview.chromium.org/2122793003
+        Cr-Commit-Position: refs/heads/master@{#37597}
+
+    Fixes: https://github.com/nodejs/node/issues/7536
+    PR-URL: https://github.com/nodejs/node/pull/7612
+    Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
+    Reviewed-By: Michaël Zasso <mic.besace@gmail.com>`
+    const data = { name: 'biscuits' }
+
+    const v = {
+      report: (obj) => {
+        tt.pass('called report')
+        tt.equal(obj.data, data, 'obj')
+      }
+    }
+    const p = new Parser(input, v)
+    const c = p.toJSON()
+    tt.equal(c.sha, '5cdbbdf94d6f656230293ddd2a71dedf11cab17d', 'sha')
+    tt.equal(c.author, 'Ben Noordhuis <info@bnoordhuis.nl>', 'author')
+    tt.equal(c.date, 'Thu Jul 7 14:29:32 2016 -0700', 'date')
+    tt.deepEqual(c.subsystems, ['deps'], 'subsystems')
+    tt.deepEqual(c.fixes, [
+      'https://github.com/nodejs/node/issues/7536'
+    ], 'fixes')
+    tt.equal(c.prUrl, 'https://github.com/nodejs/node/pull/7612', 'prUrl')
+    tt.deepEqual(c.reviewers, [
+      'Colin Ihrig <cjihrig@gmail.com>',
+      'Michaël Zasso <mic.besace@gmail.com>'
+    ], 'reviewers')
+
+    tt.equal(c.revert, false, 'revert')
+    tt.equal(c.release, false, 'release')
+    tt.equal(c.working, false, 'working')
+    tt.deepEqual(c.metadata, {
+      start: 13,
+      end: 16
+    }, 'metadata')
+    p.report(data)
+    tt.end()
+  })
+
+  t.test('release commit', (tt) => {
+    /* eslint-disable */
+    const input = `commit 6a9438343bb63e2c1fc028f2e9387e6ae41b9fc8
+Author: Evan Lucas <evanlucas@me.com>
+Date:   Thu Jun 23 07:27:44 2016 -0500
+
+    2016-06-23, Version 5.12.0 (Stable)
+
+    Notable changes:
+
+    This is a security release. All Node.js users should consult the security
+    release summary at https://nodejs.org/en/blog/vulnerability/june-2016-security-releases
+    for details on patched vulnerabilities.
+
+    * **buffer**
+      * backport allocUnsafeSlow (Сковорода Никита Андреевич) [#7169](https://github.com/nodejs/node/pull/7169)
+      * ignore negative allocation lengths (Anna Henningsen) [#7221](https://github.com/nodejs/node/pull/7221)
+    * **deps**: backport 3a9bfec from v8 upstream (Ben Noordhuis) [nodejs/node-private#40](https://github.com/nodejs/node-private/pull/40)
+      * Fixes a Buffer overflow vulnerability discovered in v8. More details
+        can be found in the CVE (CVE-2016-1699).
+
+    PR-URL: https://github.com/nodejs/node-private/pull/51`
+    /* eslint-enable */
+    const v = {
+      report: () => {}
+    }
+    const p = new Parser(input, v)
+    const c = p.toJSON()
+    tt.equal(c.sha, '6a9438343bb63e2c1fc028f2e9387e6ae41b9fc8', 'sha')
+    tt.equal(c.author, 'Evan Lucas <evanlucas@me.com>', 'author')
+    tt.equal(c.date, 'Thu Jun 23 07:27:44 2016 -0500', 'date')
+    tt.deepEqual(c.subsystems, [], 'subsystems')
+    tt.deepEqual(c.fixes, [], 'fixes')
+    tt.equal(c.prUrl, 'https://github.com/nodejs/node-private/pull/51', 'prUrl')
+    tt.deepEqual(c.reviewers, [], 'reviewers')
+    tt.deepEqual(c.metadata, {
+      start: 14,
+      end: 14
+    }, 'metadata')
+
+    tt.equal(c.revert, false, 'revert')
+    tt.equal(c.release, true, 'release')
+    tt.equal(c.working, false, 'working')
+    tt.end()
+  })
+
+  t.test('extra meta', (tt) => {
+    /* eslint-disable */
+    const input = {
+      "sha": "c5545f2c63fe30b0cfcdafab18c26df8286881d0",
+      "url": "https://api.github.com/repos/nodejs/node/git/commits/c5545f2c63fe30b0cfcdafab18c26df8286881d0",
+      "html_url": "https://github.com/nodejs/node/commit/c5545f2c63fe30b0cfcdafab18c26df8286881d0",
+      "author": {
+        "name": "Anna Henningsen",
+        "email": "anna@addaleax.net",
+        "date": "2016-09-13T10:57:49Z"
+      },
+      "committer": {
+        "name": "Anna Henningsen",
+        "email": "anna@addaleax.net",
+        "date": "2016-09-19T12:50:57Z"
+      },
+      "tree": {
+        "sha": "b505c0ffa0555730e9f4cdb391d1ebeb48bb2f59",
+        "url": "https://api.github.com/repos/nodejs/node/git/trees/b505c0ffa0555730e9f4cdb391d1ebeb48bb2f59"
+      },
+      "message": "fs: fix handling of `uv_stat_t` fields\n\n`FChown` and `Chown` test that the `uid` and `gid` parameters\nthey receive are unsigned integers, but `Stat()` and `FStat()`\nwould return the corresponding fields of `uv_stat_t` as signed\nintegers. Applications which pass those these values directly\nto `Chown` may fail\n(e.g. for `nobody` on OS X, who has an `uid` of `-2`, see e.g.\nhttps://github.com/nodejs/node-v0.x-archive/issues/5890).\n\nThis patch changes the `Integer::New()` call for `uid` and `gid`\nto `Integer::NewFromUnsigned()`.\n\nAll other fields are kept as they are, for performance, but\nstrictly speaking the respective sizes of those\nfields aren’t specified, either.\n\nRef: https://github.com/npm/npm/issues/13918\nPR-URL: https://github.com/nodejs/node/pull/8515\nReviewed-By: Ben Noordhuis <info@bnoordhuis.nl>\nReviewed-By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>\nReviewed-By: James M Snell <jasnell@gmail.com>",
+      "parents": [
+        {
+          "sha": "4e76bffc0c7076a5901179e70c7b8a8f9fcd22e4",
+          "url": "https://api.github.com/repos/nodejs/node/git/commits/4e76bffc0c7076a5901179e70c7b8a8f9fcd22e4",
+          "html_url": "https://github.com/nodejs/node/commit/4e76bffc0c7076a5901179e70c7b8a8f9fcd22e4"
+        }
+      ]
+    }
+    /* eslint-enable */
+    const v = {
+      report: () => {}
+    }
+    const p = new Parser(input, v)
+    const c = p.toJSON()
+    tt.equal(c.sha, 'c5545f2c63fe30b0cfcdafab18c26df8286881d0', 'sha')
+    tt.equal(c.author, 'Anna Henningsen <anna@addaleax.net>', 'author')
+    tt.equal(c.date, '2016-09-13T10:57:49Z', 'date')
+    tt.deepEqual(c.subsystems, ['fs'], 'subsystems')
+    tt.deepEqual(c.fixes, [], 'fixes')
+    tt.equal(c.prUrl, 'https://github.com/nodejs/node/pull/8515', 'prUrl')
+    tt.deepEqual(c.reviewers, [
+      'Ben Noordhuis <info@bnoordhuis.nl>',
+      'Sakthipriyan Vairamani <thechargingvolcano@gmail.com>',
+      'James M Snell <jasnell@gmail.com>'
+    ], 'reviewers')
+    tt.deepEqual(c.metadata, {
+      start: 16,
+      end: 20
+    }, 'metadata')
+    tt.deepEqual(c.trailers, [
+      'Ref: https://github.com/npm/npm/issues/13918',
+      'PR-URL: https://github.com/nodejs/node/pull/8515',
+      'Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>',
+      'Reviewed-By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>',
+      'Reviewed-By: James M Snell <jasnell@gmail.com>'
+    ], 'c.trailers')
+    tt.deepEqual(c.trailerFreeBody, [
+      '`FChown` and `Chown` test that the `uid` and `gid` parameters',
+      'they receive are unsigned integers, but `Stat()` and `FStat()`',
+      'would return the corresponding fields of `uv_stat_t` as signed',
+      'integers. Applications which pass those these values directly',
+      'to `Chown` may fail',
+      '(e.g. for `nobody` on OS X, who has an `uid` of `-2`, see e.g.',
+      'https://github.com/nodejs/node-v0.x-archive/issues/5890).',
+      '',
+      'This patch changes the `Integer::New()` call for `uid` and `gid`',
+      'to `Integer::NewFromUnsigned()`.',
+      '',
+      'All other fields are kept as they are, for performance, but',
+      'strictly speaking the respective sizes of those',
+      'fields aren’t specified, either.'
+    ], 'c.trailerFreeBody')
+
+    tt.equal(c.revert, false, 'revert')
+    tt.equal(c.release, false, 'release')
+    tt.equal(c.working, false, 'working')
+    tt.end()
+  })
+
+  t.end()
+})

--- a/test/rules/assisted-by-is-trailer.js
+++ b/test/rules/assisted-by-is-trailer.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/assisted-by-is-trailer.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 test('rule: assisted-by-is-trailer', (t) => {

--- a/test/rules/co-authored-by-is-trailer.js
+++ b/test/rules/co-authored-by-is-trailer.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/co-authored-by-is-trailer.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 test('rule: co-authored-by-is-trailer', (t) => {

--- a/test/rules/fixes-url.js
+++ b/test/rules/fixes-url.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/fixes-url.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 const INVALID_PRURL = 'Pull request URL must reference a comment or discussion.'

--- a/test/rules/line-after-title.js
+++ b/test/rules/line-after-title.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/line-after-title.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 test('rule: line-after-title', (t) => {

--- a/test/rules/line-length.js
+++ b/test/rules/line-length.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/line-length.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 test('rule: line-length', (t) => {
@@ -31,7 +31,8 @@ ${'aaa'.repeat(30)}`
 
     Rule.validate(context, {
       options: {
-        length: 72
+        length: 72,
+        trailerLength: 120
       }
     })
   })
@@ -59,7 +60,8 @@ ${'aaa'.repeat(30)}`
 
     Rule.validate(context, {
       options: {
-        length: 72
+        length: 72,
+        trailerLength: 120
       }
     })
     tt.end()
@@ -93,7 +95,8 @@ That was the original code.
 
     Rule.validate(context, {
       options: {
-        length: 72
+        length: 72,
+        trailerLength: 120
       }
     })
     tt.end()
@@ -111,6 +114,8 @@ That was the original code.
       message: `src: make foo mor foo-ey
 
 https://${'very-'.repeat(80)}-long-url.org/
+
+Trailer: value
 `
     }, v)
 
@@ -123,13 +128,14 @@ https://${'very-'.repeat(80)}-long-url.org/
 
     Rule.validate(context, {
       options: {
-        length: 72
+        length: 72,
+        trailerLength: 120
       }
     })
     tt.end()
   })
 
-  t.test('Co-author lines', (tt) => {
+  t.test('Co-author trailers', (tt) => {
     const v = new Validator()
 
     const good = new Commit({
@@ -141,6 +147,7 @@ https://${'very-'.repeat(80)}-long-url.org/
       },
       message: [
         'fixup!: apply case-insensitive suggestion',
+        '',
         'Co-authored-by: Michaël Zasso <37011812+targos@users.noreply.github.com>'
       ].join('\n')
     }, v)
@@ -154,14 +161,15 @@ https://${'very-'.repeat(80)}-long-url.org/
 
     Rule.validate(good, {
       options: {
-        length: 72
+        length: 72,
+        trailerLength: 120
       }
     })
 
     tt.end()
   })
 
-  t.test('Signed-off-by and Assisted-by lines', (tt) => {
+  t.test('Signed-off-by and Assisted-by trailers', (tt) => {
     const v = new Validator()
 
     const good = new Commit({
@@ -172,6 +180,8 @@ https://${'very-'.repeat(80)}-long-url.org/
         date: '2026-04-10T16:38:01Z'
       },
       message: [
+        'subsystem: foobar',
+        '',
         'Signed-off-by: John Connor <9092381+JConnor1985@users.noreply.github.com>',
         'Assisted-by: The Longest-Named Code Agent In The World <agent@example.com>'
       ].join('\n')
@@ -186,7 +196,45 @@ https://${'very-'.repeat(80)}-long-url.org/
 
     Rule.validate(good, {
       options: {
-        length: 72
+        length: 72,
+        trailerLength: 120
+      }
+    })
+
+    tt.end()
+  })
+
+  t.test('Signed-off-by and Assisted-by non-trailers', (tt) => {
+    const v = new Validator()
+
+    const context = new Commit({
+      sha: '016b3921626b58d9b595c90141e65c6fbe0c78e2',
+      author: {
+        name: 'John Connor',
+        email: '9092381+JConnor1985@users.noreply.github.com',
+        date: '2026-04-10T16:38:01Z'
+      },
+      message: [
+        'subsystem: foobar',
+        '',
+        'Signed-off-by: John Connor <9092381+JConnor1985@users.noreply.github.com>',
+        'Assisted-by: The Longest-Named Code Agent In The World <agent@example.com>',
+        '',
+        'Actual-trailer: Value'
+      ].join('\n')
+    }, v)
+
+    context.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'line-length', 'id')
+      tt.equal(opts.string, 'Assisted-by: The Longest-Named Code Agent In The World <agent@example.com>', 'string')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(context, {
+      options: {
+        length: 72,
+        trailerLength: 120
       }
     })
 

--- a/test/rules/line-length.js
+++ b/test/rules/line-length.js
@@ -205,6 +205,7 @@ Trailer: value
   })
 
   t.test('Signed-off-by and Assisted-by non-trailers', (tt) => {
+    tt.plan(8)
     const v = new Validator()
 
     const context = new Commit({
@@ -224,10 +225,14 @@ Trailer: value
       ].join('\n')
     }, v)
 
+    let called = 0
     context.report = (opts) => {
       tt.pass('called report')
       tt.equal(opts.id, 'line-length', 'id')
-      tt.equal(opts.string, 'Assisted-by: The Longest-Named Code Agent In The World <agent@example.com>', 'string')
+      tt.equal(opts.string,
+        called++
+          ? 'Assisted-by: The Longest-Named Code Agent In The World <agent@example.com>'
+          : 'Signed-off-by: John Connor <9092381+JConnor1985@users.noreply.github.com>', 'string')
       tt.equal(opts.level, 'fail', 'level')
     }
 

--- a/test/rules/line-length.js
+++ b/test/rules/line-length.js
@@ -169,6 +169,72 @@ Trailer: value
     tt.end()
   })
 
+  t.test('Multi-line trailers', (tt) => {
+    const v = new Validator()
+
+    const good = new Commit({
+      sha: 'f1496de5a7d5474e39eafaafe6f79befe5883a5b',
+      author: {
+        name: 'Jacob Smith',
+        email: '3012099+JakobJingleheimer@users.noreply.github.com',
+        date: '2025-12-22T09:40:42Z'
+      },
+      message: [
+        'subsystem: add support for foobar',
+        '',
+        'Lorem-Ipsum: dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna',
+        '  aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+        '  Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint',
+        '  occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+      ].join('\n')
+    }, v)
+    const tooLong = '  Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+    const bad = new Commit({
+      sha: 'f1496de5a7d5474e39eafaafe6f79befe5883a5b',
+      author: {
+        name: 'Jacob Smith',
+        email: '3012099+JakobJingleheimer@users.noreply.github.com',
+        date: '2025-12-22T09:40:42Z'
+      },
+      message: [
+        'subsystem: add support for foobar',
+        '',
+        'Lorem-Ipsum: dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna',
+        '  aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+        tooLong
+      ].join('\n')
+    }, v)
+
+    good.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'line-length', 'id')
+      tt.equal(opts.string, '', 'string')
+      tt.equal(opts.level, 'pass', 'level')
+    }
+    bad.report = (opts) => {
+      tt.pass('called report')
+      tt.equal(opts.id, 'line-length', 'id')
+      tt.equal(opts.message, 'Trailer should be <= 120 columns.', 'message')
+      tt.equal(opts.string, tooLong, 'string')
+      tt.equal(opts.level, 'fail', 'level')
+    }
+
+    Rule.validate(good, {
+      options: {
+        length: 72,
+        trailerLength: 120
+      }
+    })
+    Rule.validate(bad, {
+      options: {
+        length: 72,
+        trailerLength: 120
+      }
+    })
+
+    tt.end()
+  })
+
   t.test('Signed-off-by and Assisted-by trailers', (tt) => {
     const v = new Validator()
 

--- a/test/rules/reviewers.js
+++ b/test/rules/reviewers.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/reviewers.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 const MSG = 'Commit must have at least 1 reviewer.'
 

--- a/test/rules/signed-off-by.js
+++ b/test/rules/signed-off-by.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/signed-off-by.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 test('rule: signed-off-by', (t) => {

--- a/test/rules/subsystem.js
+++ b/test/rules/subsystem.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/subsystem.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 test('rule: subsystem', (t) => {

--- a/test/rules/title-format.js
+++ b/test/rules/title-format.js
@@ -1,6 +1,6 @@
 import { test } from 'tap'
 import Rule from '../../lib/rules/title-format.js'
-import Commit from 'gitlint-parser-node'
+import Commit from '../../lib/gitlint-parser.js'
 import Validator from '../../index.js'
 
 function makeCommit (title) {

--- a/test/validator.js
+++ b/test/validator.js
@@ -81,34 +81,6 @@ Date:   Thu Mar 3 10:10:46 2016 -0600
 
     Signed-off-by: Wyatt Preul <wpreul@gmail.com>`
 
-/* eslint-disable */
-const str6 = {
-  "sha": "c5545f2c63fe30b0cfcdafab18c26df8286881d0",
-  "url": "https://api.github.com/repos/nodejs/node/git/commits/c5545f2c63fe30b0cfcdafab18c26df8286881d0",
-  "html_url": "https://github.com/nodejs/node/commit/c5545f2c63fe30b0cfcdafab18c26df8286881d0",
-  "author": {
-    "name": "Anna Henningsen",
-    "email": "anna@addaleax.net",
-    "date": "2016-09-13T10:57:49Z"
-  },
-  "committer": {
-    "name": "Anna Henningsen",
-    "email": "anna@addaleax.net",
-    "date": "2016-09-19T12:50:57Z"
-  },
-  "tree": {
-    "sha": "b505c0ffa0555730e9f4cdb391d1ebeb48bb2f59",
-    "url": "https://api.github.com/repos/nodejs/node/git/trees/b505c0ffa0555730e9f4cdb391d1ebeb48bb2f59"
-  },
-  "message": "fs: fix handling of `uv_stat_t` fields\n\n`FChown` and `Chown` test that the `uid` and `gid` parameters\nthey receive are unsigned integers, but `Stat()` and `FStat()`\nwould return the corresponding fields of `uv_stat_t` as signed\nintegers. Applications which pass those these values directly\nto `Chown` may fail\n(e.g. for `nobody` on OS X, who has an `uid` of `-2`, see e.g.\nhttps://github.com/nodejs/node-v0.x-archive/issues/5890).\n\nThis patch changes the `Integer::New()` call for `uid` and `gid`\nto `Integer::NewFromUnsigned()`.\n\nAll other fields are kept as they are, for performance, but\nstrictly speaking the respective sizes of those\nfields aren’t specified, either.\n\nSigned-off-by: Anna Henningsen <anna@addaleax.net>\nRef: https://github.com/npm/npm/issues/13918\nPR-URL: https://github.com/nodejs/node/pull/8515\nReviewed-By: Ben Noordhuis <info@bnoordhuis.nl>\nReviewed-By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>\nReviewed-By: James M Snell <jasnell@gmail.com>\n\nundo accidental change to other fields of uv_fs_stat",
-  "parents": [
-    {
-      "sha": "4e76bffc0c7076a5901179e70c7b8a8f9fcd22e4",
-      "url": "https://api.github.com/repos/nodejs/node/git/commits/4e76bffc0c7076a5901179e70c7b8a8f9fcd22e4",
-      "html_url": "https://github.com/nodejs/node/commit/4e76bffc0c7076a5901179e70c7b8a8f9fcd22e4"
-    }
-  ]
-}
 /* eslint-enable */
 
 const str7 = `commit 7d3a7ea0d7df9b6f11df723dec370f49f4f87e99
@@ -289,7 +261,7 @@ test('Validator - real commits', (t) => {
       const filtered = msgs.filter((item) => {
         return item.level === 'fail'
       })
-      tt.equal(filtered.length, 0, 'messages.length')
+      tt.same(filtered, [], 'messages.length')
       tt.end()
     })
   })
@@ -387,30 +359,6 @@ test('Validator - real commits', (t) => {
         return item.level === 'fail'
       })
       tt.equal(filtered.length, 0, 'messages.length')
-      tt.end()
-    })
-  })
-
-  t.test('non empty lines after metadata', (tt) => {
-    const v = new Validator()
-    v.lint(str6)
-    v.on('commit', (data) => {
-      const c = data.commit.toJSON()
-      tt.equal(c.sha, 'c5545f2c63fe30b0cfcdafab18c26df8286881d0', 'sha')
-      tt.equal(c.date, '2016-09-13T10:57:49Z', 'date')
-      tt.same(c.subsystems, ['fs'], 'subsystems')
-      tt.equal(c.prUrl, 'https://github.com/nodejs/node/pull/8515', 'pr')
-      tt.equal(c.revert, false, 'revert')
-      const msgs = data.messages
-      const filtered = msgs.filter((item) => {
-        return item.level === 'fail'
-      })
-      tt.equal(filtered.length, 1, 'messages.length')
-      const item = filtered[0]
-      tt.equal(item.id, 'metadata-end', 'id')
-      tt.equal(item.message, 'commit metadata at end of message', 'message')
-      tt.equal(item.line, 23, 'line')
-      tt.equal(item.column, 0, 'column')
       tt.end()
     })
   })


### PR DESCRIPTION
The goal is to allow longer lines for commit trailers, as the 72 limit is just too low in many legitimate case. Setting 120 seems more reasonable. Multi-lines trailers are also supported

This PR moves https://github.com/git-lint/gitlint-parser-node into this repo to ease maintenance