### PR TITLE
feat!: drop support for Node.js 20.x and 25.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "core-validate-commit": "./bin/cmd.js"
   },
   "engines": {
-    "node": "^20.19.6 || ^22.21.1 || >=24.12.0"
+    "node": "^22.21.1 || ^24.12.0 || >=26.0.0"
   },
   "author": "Evan Lucas <evanlucas@me.com>",
   "repository": {


### PR DESCRIPTION
Since we're cutting a new major in https://github.com/nodejs/core-validate-commit/pull/143, it probably make sense to remove support for Node.js versions that quite close to EOL