### PR TITLE
chore: replace shrinkwrap with package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "gitlint-parser-base": "^2.0.0"
+        "gitlint-parser-base": "2.0.0"
       },
       "bin": {
         "core-validate-commit": "bin/cmd.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "gitlint-parser-base": "2.0.0"
+        "gitlint-parser-base": "^2.0.0"
       },
       "bin": {
         "core-validate-commit": "bin/cmd.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "core-validate-commit",
       "version": "6.0.0",
+      "bundleDependencies": [
+        "gitlint-parser-base"
+      ],
       "license": "MIT",
       "dependencies": {
         "gitlint-parser-base": "2.0.0"
@@ -1812,6 +1815,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gitlint-parser-base/-/gitlint-parser-base-2.0.0.tgz",
       "integrity": "sha512-kWkbGGH55AigPQgTz9ZEomv8uQn2GRZiFgAg+SbTIV+8ineU8f3QDeAQHzS7h9yKVuE7cjcgQm0ENmHPM0bxMQ==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "gitlint-parser-base": "2.0.0"
   },
+  "bundleDependencies": true,
   "devDependencies": {
     "check-pkg": "^2.1.1",
     "standard": "^17.0.0"

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "test-ci": "npm test -- --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "dependencies": {
-    "gitlint-parser-base": "2.0.0"
+    "gitlint-parser-base": "^2.0.0"
   },
-  "bundleDependencies": true,
   "devDependencies": {
     "check-pkg": "^2.1.1",
     "standard": "^17.0.0"
   },
+  "bundleDependencies": true,
   "files": [
     "lib/",
     "bin/",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-ci": "npm test -- --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "dependencies": {
-    "gitlint-parser-base": "^2.0.0"
+    "gitlint-parser-base": "2.0.0"
   },
   "devDependencies": {
     "check-pkg": "^2.1.1",
@@ -19,7 +19,6 @@
   "files": [
     "lib/",
     "bin/",
-    "npm-shrinkwrap.json",
     "index.js"
   ],
   "license": "MIT",


### PR DESCRIPTION
`npm-shrinkwrap.json` was added in #134 to pin the transitive dependencies of `gitlint-parser-node`.

Since #144 moved that package into this repository, the only remaining runtime dependency is the dependency-free `gitlint-parser-base` whose last publish was in 2016.

This PR:

- Pins `gitlint-parser-base` to `2.0.0`.
- Replaces the published shrinkwrap with a development-only `package-lock.json`.
- Avoids publishing dev-dependency metadata.

This will be required to work with npm 12, which has [removed support for `npm-shrinkwrap.json`](https://github.com/npm/cli/releases/tag/v12.0.0).

---

Assisted-by: codex:gpt-5.6-sol